### PR TITLE
Tighten README for public audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,35 +20,31 @@ Dreadnode Capabilities
 
 </br>
 
-This is the source repo for the capabilities Dreadnode publishes to [app.dreadnode.io](https://app.dreadnode.io). A capability is a directory — a manifest plus any combination of agents, tools, skills, MCP servers, and workers — that a Dreadnode runtime can pick up and load:
+This is the source repo for the capabilities Dreadnode publishes to [app.dreadnode.io](https://app.dreadnode.io). A capability is a directory — a manifest plus any combination of agents, tools, skills, and MCP servers — that a Dreadnode runtime picks up and loads:
 
 ```text
-threat-hunting/
+ai-red-teaming/
   capability.yaml     # manifest
   agents/             # markdown prompts
   tools/              # python @tool functions
   skills/             # SKILL.md packs
 ```
 
-Welcome — the rest of this README is a quick map to wherever you're trying to go.
+## Install one
 
-## Looking to use one?
+- **Published** — `dn capability install dreadnode/ai-red-teaming` (swap in any name from `capabilities/`)
+- **From source** — `dn capability install ./capabilities/ai-red-teaming` symlinks the directory into your runtime, so edits go live on reload
+- **From the TUI** — start `dn`, press `Ctrl+P`, filter for `dreadnode/`
 
-Pick whichever fits — same capabilities, three ways in:
+`dn` is the Dreadnode CLI — see [getting-started](https://docs.dreadnode.io/getting-started/quickstart/) to install and authenticate. Full install reference for capabilities lives at [docs.dreadnode.io/capabilities/installing](https://docs.dreadnode.io/capabilities/installing/).
 
-- **Install the published version** — `dn capability install dreadnode/ai-red-teaming` (swap in any name from `capabilities/`)
-- **Run the source from this repo** — `dn capability install ./capabilities/ai-red-teaming` symlinks the directory into your runtime, so edits go live on reload
-- **Browse from inside the runtime** — start `dn`, press `Ctrl+P`, filter for `dreadnode/`
+## Build your own
 
-Full install reference: [docs.dreadnode.io/capabilities/installing](https://docs.dreadnode.io/capabilities/installing/).
+Every directory under `capabilities/` is a shipped, working example. Read one alongside the docs:
 
-## Curious how they work, or want to build one?
-
-This is a great place to be — every directory under `capabilities/` is a real, shipped example you can read alongside the docs:
-
-- **Concepts and load model** — [overview](https://docs.dreadnode.io/capabilities/overview/)
-- **Manifest reference** — [manifest](https://docs.dreadnode.io/capabilities/manifest/)
-- **End-to-end walkthrough** — [quickstart](https://docs.dreadnode.io/capabilities/quickstart/) (~10 minutes from scaffold to running in the TUI)
+- [Concepts and load model](https://docs.dreadnode.io/capabilities/overview/)
+- [Manifest reference](https://docs.dreadnode.io/capabilities/manifest/)
+- [Quickstart](https://docs.dreadnode.io/capabilities/quickstart/) — scaffold to running in the TUI in about ten minutes
 
 ## Security scanning
 
@@ -66,4 +62,4 @@ This repo is published for reference, not as a contribution target — we don't 
 
 ## License
 
-Each capability declares its own license in its `capability.yaml`. Most are MIT — check the manifest of the capability you're using.
+Each capability declares its license in its `capability.yaml`.


### PR DESCRIPTION
## Summary

Top-down pass on the README now that the repo is public. Every change is either a contextual mismatch fix or a coverage gap close — voice nits left alone.

- Replace fictional `threat-hunting/` directory tree with a real `ai-red-teaming/` shape that matches the install bullets below.
- Drop `workers` from the component list — none of the 15 capabilities in this repo ships one.
- Direct headings (`Install one`, `Build your own`) in place of question-form ones; cut the meta "welcome" line and the "great place to be" hype.
- Add a one-liner pointing readers at getting-started so `dn capability install …` isn't an unexplained command for anyone landing here cold.
- Stop claiming "Most are MIT" in the License section — point at each capability's `capability.yaml` so the README doesn't have to track licensing changes.

## Test plan

- [x] `pre-commit run --files README.md` passes
- [x] All linked doc URLs return 200 (`docs.dreadnode.io/getting-started/quickstart/`, `…/capabilities/{installing,overview,manifest,quickstart}/`)
- [x] `ai-red-teaming/` and `web-security/` referenced in examples exist on disk
- [ ] Skim the rendered README on the PR page to confirm the new flow reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)