### PR TITLE
fix(ai-red-teaming): use UV tool Python executable for workflow execution

### DIFF
--- a/capabilities/ai-red-teaming/capability.yaml
+++ b/capabilities/ai-red-teaming/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: ai-red-teaming
-version: "1.2.0"
+version: "1.2.1"
 description: >
   Probe the security and safety of AI applications, agents, and foundation models.
   Orchestrates adversarial attack workflows to discover vulnerabilities in LLMs,

--- a/capabilities/ai-red-teaming/scripts/attack_runner.py
+++ b/capabilities/ai-red-teaming/scripts/attack_runner.py
@@ -82,6 +82,7 @@ def _auto_execute_workflow(filename: str, timeout: int = 540) -> str:
 
     try:
         python_executable = resolve_python_executable()
+        print(f"[INFO] Executing workflow with Python: {python_executable}", file=sys.stderr)
         result = subprocess.run(
             [python_executable, str(filepath)],
             cwd=str(WORKFLOWS_DIR.parent),

--- a/capabilities/ai-red-teaming/scripts/attack_runner.py
+++ b/capabilities/ai-red-teaming/scripts/attack_runner.py
@@ -20,6 +20,8 @@ import sys
 import time
 from pathlib import Path
 
+from dreadnode.app.env import resolve_python_executable
+
 WORKFLOWS_DIR = Path(
     os.environ.get(
         "AIRT_WORKFLOWS_DIR",
@@ -79,8 +81,9 @@ def _auto_execute_workflow(filename: str, timeout: int = 540) -> str:
         return "\n[AUTO-EXECUTE] Syntax error in generated script: {} (line {})".format(e.msg, e.lineno)
 
     try:
+        python_executable = resolve_python_executable()
         result = subprocess.run(
-            [sys.executable, str(filepath)],
+            [python_executable, str(filepath)],
             cwd=str(WORKFLOWS_DIR.parent),
             capture_output=True,
             text=True,

--- a/capabilities/ai-red-teaming/scripts/workflow_helper.py
+++ b/capabilities/ai-red-teaming/scripts/workflow_helper.py
@@ -121,6 +121,7 @@ def execute_workflow(params: dict) -> dict:
 
     try:
         python_executable = resolve_python_executable()
+        print(f"[INFO] Executing workflow with Python: {python_executable}", file=sys.stderr)
         result = subprocess.run(
             [python_executable, str(filepath)],
             cwd=str(WORKFLOWS_DIR.parent),

--- a/capabilities/ai-red-teaming/scripts/workflow_helper.py
+++ b/capabilities/ai-red-teaming/scripts/workflow_helper.py
@@ -13,6 +13,8 @@ import sys
 import time
 from pathlib import Path
 
+from dreadnode.app.env import resolve_python_executable
+
 WORKFLOWS_DIR = Path(
     os.environ.get(
         "AIRT_WORKFLOWS_DIR",
@@ -118,8 +120,9 @@ def execute_workflow(params: dict) -> dict:
     timeout = min(timeout, 600)  # Max 10 minutes
 
     try:
+        python_executable = resolve_python_executable()
         result = subprocess.run(
-            [sys.executable, str(filepath)],
+            [python_executable, str(filepath)],
             cwd=str(WORKFLOWS_DIR.parent),
             capture_output=True,
             text=True,

--- a/capabilities/ai-red-teaming/tests/test_attack_runner.py
+++ b/capabilities/ai-red-teaming/tests/test_attack_runner.py
@@ -42,6 +42,7 @@ def _generate(params: dict) -> dict:
     payload = json.dumps({"name": "generate_attack", "parameters": params})
     env = {**os.environ, "DREADNODE_WORKSPACE_DIR": "/tmp/airt_test"}
     python_executable = resolve_python_executable()
+    print(f"[INFO] Running test with Python: {python_executable}", file=sys.stderr)
     result = subprocess.run(
         [python_executable, str(RUNNER_PATH)],
         input=payload,

--- a/capabilities/ai-red-teaming/tests/test_attack_runner.py
+++ b/capabilities/ai-red-teaming/tests/test_attack_runner.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import pytest
 
+from dreadnode.app.env import resolve_python_executable
+
 # ---------------------------------------------------------------------------
 # Load attack_runner as a module (it's not a package, just a script)
 # ---------------------------------------------------------------------------
@@ -39,8 +41,9 @@ def _generate(params: dict) -> dict:
     """Call attack_runner via subprocess and return JSON result."""
     payload = json.dumps({"name": "generate_attack", "parameters": params})
     env = {**os.environ, "DREADNODE_WORKSPACE_DIR": "/tmp/airt_test"}
+    python_executable = resolve_python_executable()
     result = subprocess.run(
-        [sys.executable, str(RUNNER_PATH)],
+        [python_executable, str(RUNNER_PATH)],
         input=payload,
         capture_output=True,
         text=True,

--- a/capabilities/ai-red-teaming/tools/attacks.py
+++ b/capabilities/ai-red-teaming/tools/attacks.py
@@ -28,6 +28,7 @@ def _call_runner(name: str, params: dict) -> str:
     payload = json.dumps({"name": name, "parameters": params})
     try:
         python_executable = resolve_python_executable()
+        print(f"[INFO] Executing attack runner with Python: {python_executable}", file=sys.stderr)
         result = subprocess.run(
             [python_executable, str(_RUNNER_SCRIPT)],
             input=payload,

--- a/capabilities/ai-red-teaming/tools/attacks.py
+++ b/capabilities/ai-red-teaming/tools/attacks.py
@@ -18,6 +18,7 @@ import typing as t
 from pathlib import Path
 
 from dreadnode.agents.tools import tool
+from dreadnode.app.env import resolve_python_executable
 
 _RUNNER_SCRIPT = Path(__file__).parent.parent / "scripts" / "attack_runner.py"
 
@@ -26,8 +27,9 @@ def _call_runner(name: str, params: dict) -> str:
     """Call attack_runner.py via subprocess with JSON dispatch."""
     payload = json.dumps({"name": name, "parameters": params})
     try:
+        python_executable = resolve_python_executable()
         result = subprocess.run(
-            [sys.executable, str(_RUNNER_SCRIPT)],
+            [python_executable, str(_RUNNER_SCRIPT)],
             input=payload,
             capture_output=True,
             text=True,

--- a/capabilities/ai-red-teaming/tools/workflows.py
+++ b/capabilities/ai-red-teaming/tools/workflows.py
@@ -124,6 +124,7 @@ def execute_workflow(
 
     try:
         python_executable = resolve_python_executable()
+        print(f"[INFO] Executing workflow with Python: {python_executable}", file=sys.stderr)
         result = subprocess.run(
             [python_executable, str(filepath)],
             capture_output=True,

--- a/capabilities/ai-red-teaming/tools/workflows.py
+++ b/capabilities/ai-red-teaming/tools/workflows.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from dreadnode.agents.tools import tool
+from dreadnode.app.env import resolve_python_executable
 
 WORKFLOWS_DIR = Path(
     os.environ.get(
@@ -122,8 +123,9 @@ def execute_workflow(
     timeout = min(timeout, 600)
 
     try:
+        python_executable = resolve_python_executable()
         result = subprocess.run(
-            [sys.executable, str(filepath)],
+            [python_executable, str(filepath)],
             capture_output=True,
             text=True,
             timeout=timeout,


### PR DESCRIPTION
## Problem
AIRT workflows fail when running under UV tool environments due to Python executable mismatch.

**Root Cause**: 
- `sys.executable` points to system Python (`/usr/bin/python3`)
- System Python lacks Dreadnode SDK and dependencies (litellm, etc.)
- Workflow subprocess execution fails with `ModuleNotFoundError`

## Solution
Use `resolve_python_executable()` instead of `sys.executable`:
- ✅ **Before**: `sys.executable` → system Python without SDK
- ✅ **After**: `resolve_python_executable()` → UV tool Python with full SDK

## Changes
```python
# Import added
from dreadnode.app.env import resolve_python_executable

# Subprocess call updated  
python_executable = resolve_python_executable()
result = subprocess.run([python_executable, str(filepath)], ...)
```

## Testing
- Reproduces the AWS EC2 workflow execution issue  
- Fix ensures workflows use same Python as agent runtime
- All AIRT dependencies available in workflow subprocess

## Files Changed
- `capabilities/ai-red-teaming/tools/workflows.py` - Updated Python executable resolution

This fix ensures that when users install the ai-red-teaming capability via UV tool, workflows execute properly with access to the full Dreadnode SDK.