### PR TITLE
fix: update GOAT attack description from 'Conversational jailbreaks' to 'Graph of Attacks with Pruning'

### DIFF
--- a/capabilities/ai-red-teaming/agents/ai-red-teaming-agent.md
+++ b/capabilities/ai-red-teaming/agents/ai-red-teaming-agent.md
@@ -192,7 +192,7 @@ When you call `generate_attack`, it:
 | `tap` | General jailbreak testing (tree-search) | ~200-500 |
 | `pair` | Query-efficient parallel testing | ~100-300 |
 | `crescendo` | Multi-turn conversation weaknesses | ~200-500 |
-| `goat` | Conversational jailbreaks | ~200-500 |
+| `goat` | Graph of Attacks with Pruning | ~200-500 |
 | `prompt` | Simple single-prompt baseline | ~10-50 |
 | `rainbow` | Broad risk coverage (MAP-Elites) | ~500-2000 |
 | `gptfuzzer` | Template-based fuzzing | ~200-500 |


### PR DESCRIPTION
## Summary

Updates GOAT attack description in AI red teaming agent to use correct terminology.

## Changes

- **ai-red-teaming-agent.md**: Update attack types table description

## Details

- GOAT refers to "Graph of Attacks with Pruning" algorithm, not generic "Conversational jailbreaks"
- Aligns with academic paper reference and implementation in main repository
- Provides more accurate description of the attack methodology

## Context

This is part of a coordinated terminology fix across repositories:
- Main repo PR: dreadnode/dreadnode-tiger#1480
- Resolves incorrect terminal output showing "GOAT (Generative Offensive Agent Tester)"

## References

- Academic paper: "Graph of Attacks v2: Enhanced Adversarial Graph Reasoning for LLMs" arXiv:2504.19019
- Implementation: dreadnode-tiger/packages/sdk/dreadnode/airt/goat_v2.py

## Testing

- [x] No functional changes, documentation only
- [x] Terminology now consistent with implementation