### PR TITLE
docs(airt): expand goal_category list in agent prompt (1.3.1)

### DIFF
--- a/capabilities/ai-red-teaming/agents/ai-red-teaming-agent.md
+++ b/capabilities/ai-red-teaming/agents/ai-red-teaming-agent.md
@@ -204,7 +204,7 @@ The capability ships 41 LLM attack algorithms plus 4 adversarial ML samplers; th
 | compare_transforms | No | true = N+1 study (baseline + each transform individually) |
 | scorers | No | Additional scorers (see scorer catalog below) |
 | n_iterations | No | Max iterations (defaults vary by attack) |
-| goal_category | No | Category: jailbreak, credential_leak, tool_misuse, system_prompt_leak, harmful_content, pii, refusal_bypass, bias, content_policy |
+| goal_category | No | Canonical slug. Core: `jailbreak_general`, `credential_leak`, `tool_misuse`, `system_prompt_leak`, `harmful_content`, `pii_extraction`, `refusal_bypass`, `bias_fairness`, `content_policy`. Extended: `reasoning_exploitation`, `supply_chain`, `resource_exhaustion`, `quantization_safety`, `alignment_integrity`, `multi_turn_escalation`. Short aliases (e.g. `pii`, `bias`, `jailbreak`) also resolve. |
 | assessment_name | No | Name for assessment tracking |
 
 ## Transform Catalog

--- a/capabilities/ai-red-teaming/capability.yaml
+++ b/capabilities/ai-red-teaming/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: ai-red-teaming
-version: "1.3.0"
+version: "1.3.1"
 description: >
   Probe the security and safety of AI applications, agents, and foundation models.
   Orchestrates adversarial attack workflows to discover vulnerabilities in LLMs,


### PR DESCRIPTION
## Summary

End-to-end audit of `agents/ai-red-teaming-agent.md` against the runner source. Found one verifiable gap in the `generate_attack` parameter table:

- **`goal_category` row was incomplete.** It listed 9 categories, but `GOAL_CATEGORY_ALIASES` in `scripts/attack_runner.py` defines 15 canonical slugs. Missing from the doc: `reasoning_exploitation`, `supply_chain`, `resource_exhaustion`, `quantization_safety`, `alignment_integrity`, `multi_turn_escalation`. The agent therefore never offered these to users.
- Switched the listed values to **canonical slugs** (e.g. `pii_extraction` over `pii`, `bias_fairness` over `bias`, `jailbreak_general` over `jailbreak`) while noting that the short aliases still resolve.

Other items checked and intentionally left alone:
- Model alias table — verified against `MODEL_ALIASES` in `attack_runner.py`, all entries match.
- Frontmatter `model:` pin — config decision, out of scope.
- Attack types table — already correctly labeled as "common subset (12 of 45)".
- Tool list — matches the registered tools after the 1.3.0 cleanup.

Capability bumped to **1.3.1**.

## Test plan

- [x] `pre-commit run --files <changed>` — all green
- [x] Verified all listed slugs (canonical + aliases) exist as keys in `GOAL_CATEGORY_ALIASES`

🤖 Generated with [Claude Code](https://claude.com/claude-code)