### PR TITLE
feat: add waymore to web-security capability runtime

### DIFF
--- a/capabilities/web-security/capability.yaml
+++ b/capabilities/web-security/capability.yaml
@@ -75,6 +75,8 @@ checks:
     command: command -v caido-cli
   - name: burp
     command: test -f /opt/burp/burpsuite.jar
+  - name: waymore
+    command: command -v waymore
   - name: jxscout
     command: command -v jxscout-pro-v2
 

--- a/capabilities/web-security/scripts/install_tools.sh
+++ b/capabilities/web-security/scripts/install_tools.sh
@@ -104,6 +104,9 @@ fi
 npm install -g agent-browser
 agent-browser install || true
 
+# -- waymore (Wayback Machine recon) -----------------------------------------
+pip install --break-system-packages waymore
+
 # -- Clean up Go build cache -----------------------------------------------
 go clean -cache -modcache 2>/dev/null || true
 


### PR DESCRIPTION
Wayback Machine + CommonCrawl + OTX + URLScan + VirusTotal historical URL and response retrieval for recon and JS archaeology.

Add waymore (xnl-h4ck3r) to web-security runtime for historical URL/response retrieval from Wayback Machine, CommonCrawl, OTX, URLScan, and VirusTotal. Enables JS archaeology and endpoint discovery from archived content.

Changes:
- `install_tools.sh`: pip install waymore
- `capability.yaml`: add waymore check