### PR TITLE
fix: pass Linear credentials to web-security MCP

### DIFF
--- a/capabilities/web-security/capability.yaml
+++ b/capabilities/web-security/capability.yaml
@@ -40,6 +40,10 @@ mcp:
       args:
         - "run"
         - "${CAPABILITY_ROOT}/mcp/linear.py"
+      env:
+        LINEAR_API_KEY: "${LINEAR_API_KEY:-}"
+        LINEAR_ACCESS_TOKEN: "${LINEAR_ACCESS_TOKEN:-}"
+        LINEAR_API_URL: "${LINEAR_API_URL:-https://api.linear.app/graphql}"
       init_timeout: 60
     agent-browser:
       command: "uv"


### PR DESCRIPTION
## Summary

Adds explicit environment passthrough for the Linear MCP server in the `web-security` capability.

missed commit fix from #25 

During TUI smoke testing, the Linear MCP server loaded successfully but did not receive shell-provided Linear credentials unless the manifest declared them in the MCP server `env:` block. This updates the merged Linear connector manifest wiring so `LINEAR_API_KEY`, `LINEAR_ACCESS_TOKEN`, and optional `LINEAR_API_URL` are expanded and passed to the stdio MCP process.

## Validation

- `pre-commit run --files capabilities/web-security/capability.yaml` passed.
- `just validate` completed with 0 failures.
- TUI smoke confirmed locally with `LINEAR_API_KEY` after applying the same manifest env passthrough.

Known `just validate` warnings are pre-existing environment warnings unrelated to this change: `bloodhound-enterprise` runtime imports, local web-security `caido-cli`/Burp checks, and `windows-reversing` Java 17 check.
