### PR TITLE
Bump capability versions missed in PR #40

### DIFF
--- a/capabilities/dotnet-reversing/capability.yaml
+++ b/capabilities/dotnet-reversing/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: dotnet-reversing
-version: "1.0.0"
+version: "1.0.1"
 description: >
   .NET reverse engineering for decompiling and analyzing assemblies
   (.dll, .exe). Provides binary scanning, namespace exploration, type

--- a/capabilities/web-security/capability.yaml
+++ b/capabilities/web-security/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: web-security
-version: "1.1.1"
+version: "1.1.2"
 description: >
   Web application penetration testing with 60+ attack technique playbooks
   covering request smuggling, cache poisoning, SSRF, SSTI, DOM


### PR DESCRIPTION
PR #40 updated skills and agents in `dotnet-reversing` and `web-security` but did not bump their `capability.yaml` versions.

## Changed
- `dotnet-reversing` version bumped from `1.0.0` to `1.0.1`
- `web-security` version bumped from `1.1.1` to `1.1.2`