### PR TITLE
fix: skip airt_* kwargs for attacks that don't support them

### DIFF
--- a/capabilities/ai-red-teaming/capability.yaml
+++ b/capabilities/ai-red-teaming/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: ai-red-teaming
-version: "1.3.7"
+version: "1.4.0"
 description: >
   Probe the security and safety of AI applications, agents, and foundation models.
   Orchestrates adversarial attack workflows to discover vulnerabilities in LLMs,

--- a/capabilities/ai-red-teaming/scripts/attack_runner.py
+++ b/capabilities/ai-red-teaming/scripts/attack_runner.py
@@ -55,42 +55,39 @@ METADATA_FILE = WORKFLOWS_DIR / ".workflow_metadata.json"
 def _resolve_platform_env() -> dict[str, str]:
     """Build env dict with platform credentials for subprocess execution.
 
-    In sandbox mode, env vars are already set. In TUI/CLI mode, reads from
-    the saved profile at ~/.cache/dreadnode/config.yaml.
+    In sandbox mode, env vars are already set (DREADNODE_SERVER + API_KEY).
+    In TUI mode, the runtime sets DREADNODE_LLM_BASE + LLM_API_KEY for the
+    LLM proxy but does NOT set SERVER/API_KEY/ORG/WORKSPACE/PROJECT — those
+    come from the saved profile (``dn login``).
+
+    We ALWAYS read the saved profile to fill in scope vars (org, workspace,
+    project) so the subprocess respects the user's TUI context.  ``setdefault``
+    ensures explicit env vars (sandbox) take precedence over the profile.
     """
     env = os.environ.copy()
 
-    # If the runtime already provides platform credentials in any of the
-    # forms the SDK understands, pass the env through untouched -- the
-    # generated script self-configures via dn.configure(), whose precedence
-    # is: explicit args > env vars > saved profile.
-    #   - DREADNODE_SERVER + DREADNODE_API_KEY  (classic platform env)
-    #   - DREADNODE_LLM_BASE + DREADNODE_LLM_API_KEY  (runtime LLM proxy env)
-    if env.get("DREADNODE_SERVER") and env.get("DREADNODE_API_KEY"):
-        return env
-    if env.get("DREADNODE_LLM_BASE") and env.get("DREADNODE_LLM_API_KEY"):
-        return env
-
-    # Fall back to saved profile (TUI/CLI mode)
-    # Profile lives at ~/.dreadnode/config.yaml (YAML format)
+    # Read saved profile via the SDK's own config system.  This respects
+    # ``dn login``, ``/workspace`` switches, and profile selection — no
+    # need to parse YAML manually.
     try:
-        from pathlib import Path as _Path
-        import yaml  # type: ignore[import-untyped]
+        from dreadnode.app.config import UserConfig
 
-        config_path = _Path.home() / ".dreadnode" / "config.yaml"
-        if config_path.exists():
-            config = yaml.safe_load(config_path.read_text())
-            active = config.get("active")
-            servers = config.get("servers", {})
-            if active and active in servers:
-                profile = servers[active]
-                env.setdefault("DREADNODE_SERVER", profile.get("url", ""))
-                env.setdefault("DREADNODE_API_KEY", profile.get("api_key", ""))
-                env.setdefault("DREADNODE_ORGANIZATION", profile.get("default_organization", ""))
-                env.setdefault("DREADNODE_WORKSPACE", profile.get("default_workspace", ""))
-                env.setdefault("DREADNODE_PROJECT", profile.get("default_project", ""))
+        config = UserConfig.read()
+        profile_data = config.active_profile
+        if profile_data:
+            _, profile = profile_data
+            if profile.url:
+                env.setdefault("DREADNODE_SERVER", profile.url)
+            if profile.api_key:
+                env.setdefault("DREADNODE_API_KEY", profile.api_key)
+            if profile.organization:
+                env.setdefault("DREADNODE_ORGANIZATION", profile.organization)
+            if profile.workspace:
+                env.setdefault("DREADNODE_WORKSPACE", profile.workspace)
+            if profile.project:
+                env.setdefault("DREADNODE_PROJECT", profile.project)
     except Exception:
-        pass  # Best-effort — will fail later in the script with a clear error
+        pass  # Best-effort — dn.configure() in the script will try again
 
     return env
 

--- a/capabilities/ai-red-teaming/scripts/attack_runner.py
+++ b/capabilities/ai-red-teaming/scripts/attack_runner.py
@@ -775,6 +775,25 @@ ATTACK_ALIASES["j2"] = "j2_meta_attack"
 ATTACK_ALIASES["tmap"] = "tmap_trajectory_attack"
 ATTACK_ALIASES["aprt"] = "aprt_progressive_attack"
 
+# Attacks that do NOT accept airt_* span-linkage kwargs.
+# Determined by inspecting SDK function signatures. When airt_* kwargs are
+# absent, the platform may not link traces to the assessment — but passing
+# unsupported kwargs causes a hard TypeError crash, which is worse.
+_ATTACKS_WITHOUT_AIRT_KWARGS: set[str] = {
+    "rainbow_attack",
+    "gptfuzzer_attack",
+    "autodan_turbo_attack",
+    "renellm_attack",
+    "beast_attack",
+    "drattack",
+    "deep_inception_attack",
+    "hopskipjump_attack",
+    "simba_attack",
+    "nes_attack",
+    "zoo_attack",
+    "multimodal_attack",
+}
+
 _TRANSFORM_DEFS: dict[str, dict] = {
     # encoding
     "base64_encode": {"module": "dreadnode.transforms.encoding", "name": "base64_encode", "code": "base64_encode()"},
@@ -3144,10 +3163,14 @@ def _build_attack_params(
         params.append("{}={}".format(k, v))
     if transforms_expr is not None:
         params.append("transforms={}".format(transforms_expr))
-    # AIRT span linkage — links Study-created spans to assessment in ClickHouse
-    params.append("airt_assessment_id=assessment.assessment_id")
-    params.append("airt_goal_category={}".format(goal_category_expr))
-    params.append("airt_target_model=TARGET_MODEL")
+    # AIRT span linkage — links Study-created spans to assessment in ClickHouse.
+    # Only pass these kwargs to attacks that accept them; older attacks raise
+    # TypeError on unknown kwargs (see _ATTACKS_WITHOUT_AIRT_KWARGS).
+    canon = atk.get("canonical_name", atk.get("function", ""))
+    if canon not in _ATTACKS_WITHOUT_AIRT_KWARGS:
+        params.append("airt_assessment_id=assessment.assessment_id")
+        params.append("airt_goal_category={}".format(goal_category_expr))
+        params.append("airt_target_model=TARGET_MODEL")
     return ",\n        ".join(params)
 
 
@@ -3358,12 +3381,13 @@ def _generate_transform_study(config: dict) -> str:
     for k, v in atk.get("extra_defaults", {}).items():
         params.append("{}={}".format(k, v))
     params.append("transforms=transforms")
-    params.append("airt_assessment_id=assessment.assessment_id")
-    params.append("airt_goal_category=GOAL_CATEGORY.value")
-    params.append("airt_target_model=TARGET_MODEL")
-    attack_params = ",\n                ".join(params)
-
+    # Only pass airt_* kwargs to attacks that accept them
     canon = atk["canonical_name"]
+    if canon not in _ATTACKS_WITHOUT_AIRT_KWARGS:
+        params.append("airt_assessment_id=assessment.assessment_id")
+        params.append("airt_goal_category=GOAL_CATEGORY.value")
+        params.append("airt_target_model=TARGET_MODEL")
+    attack_params = ",\n                ".join(params)
     assessment_name = _safe_str(config.get("assessment_name") or "{} Transform Comparison".format(canon))
     assessment_kwargs = _build_assessment_kwargs(config, assessment_name, config.get("filename", ""))
 
@@ -3577,6 +3601,17 @@ async def main():
                     sys.stdout.flush()
 
                     try:
+                        # Build airt_* kwargs only for attacks that accept them
+                        import inspect as _inspect
+                        _sig = _inspect.signature(attack_fn)
+                        _airt_kw = {{}}
+                        if "airt_assessment_id" in _sig.parameters:
+                            _airt_kw["airt_assessment_id"] = assessment.assessment_id
+                            _airt_kw["airt_goal_category"] = goal_cat.value
+                            _airt_kw["airt_category"] = goal_row.get("category", "")
+                            _airt_kw["airt_sub_category"] = goal_sub
+                            _airt_kw["airt_target_model"] = TARGET_MODEL
+
                         study = attack_fn(
                             {attack_params},
                         )
@@ -3718,11 +3753,9 @@ def _generate_category_attack(config: dict) -> str:
     if transforms:
         transforms_expr = "[{}]".format(", ".join(t["code"] for t in transforms))
         params.append("transforms={}".format(transforms_expr))
-    params.append("airt_assessment_id=assessment.assessment_id")
-    params.append("airt_goal_category=goal_cat.value")
-    params.append("airt_category=goal_row.get('category', '')")
-    params.append("airt_sub_category=goal_sub")
-    params.append("airt_target_model=TARGET_MODEL")
+    # Build airt_* kwargs dict conditionally — only pass to attacks that accept them.
+    # The template uses **_airt_kw which unpacks to nothing for unsupported attacks.
+    params.append("**_airt_kw")
     attack_params = ",\n                        ".join(params)
 
     transform_names = [t["resolved_name"] for t in transforms] if transforms else []

--- a/capabilities/ai-red-teaming/scripts/attack_runner.py
+++ b/capabilities/ai-red-teaming/scripts/attack_runner.py
@@ -775,24 +775,7 @@ ATTACK_ALIASES["j2"] = "j2_meta_attack"
 ATTACK_ALIASES["tmap"] = "tmap_trajectory_attack"
 ATTACK_ALIASES["aprt"] = "aprt_progressive_attack"
 
-# Attacks that do NOT accept airt_* span-linkage kwargs.
-# Determined by inspecting SDK function signatures. When airt_* kwargs are
-# absent, the platform may not link traces to the assessment — but passing
-# unsupported kwargs causes a hard TypeError crash, which is worse.
-_ATTACKS_WITHOUT_AIRT_KWARGS: set[str] = {
-    "rainbow_attack",
-    "gptfuzzer_attack",
-    "autodan_turbo_attack",
-    "renellm_attack",
-    "beast_attack",
-    "drattack",
-    "deep_inception_attack",
-    "hopskipjump_attack",
-    "simba_attack",
-    "nes_attack",
-    "zoo_attack",
-    "multimodal_attack",
-}
+
 
 _TRANSFORM_DEFS: dict[str, dict] = {
     # encoding
@@ -3164,13 +3147,10 @@ def _build_attack_params(
     if transforms_expr is not None:
         params.append("transforms={}".format(transforms_expr))
     # AIRT span linkage — links Study-created spans to assessment in ClickHouse.
-    # Only pass these kwargs to attacks that accept them; older attacks raise
-    # TypeError on unknown kwargs (see _ATTACKS_WITHOUT_AIRT_KWARGS).
-    canon = atk.get("canonical_name", atk.get("function", ""))
-    if canon not in _ATTACKS_WITHOUT_AIRT_KWARGS:
-        params.append("airt_assessment_id=assessment.assessment_id")
-        params.append("airt_goal_category={}".format(goal_category_expr))
-        params.append("airt_target_model=TARGET_MODEL")
+    # All SDK attacks accept these kwargs as of dreadnode-tiger#1693.
+    params.append("airt_assessment_id=assessment.assessment_id")
+    params.append("airt_goal_category={}".format(goal_category_expr))
+    params.append("airt_target_model=TARGET_MODEL")
     return ",\n        ".join(params)
 
 
@@ -3381,12 +3361,11 @@ def _generate_transform_study(config: dict) -> str:
     for k, v in atk.get("extra_defaults", {}).items():
         params.append("{}={}".format(k, v))
     params.append("transforms=transforms")
-    # Only pass airt_* kwargs to attacks that accept them
+    # AIRT span linkage — all attacks accept these as of dreadnode-tiger#1693
+    params.append("airt_assessment_id=assessment.assessment_id")
+    params.append("airt_goal_category=GOAL_CATEGORY.value")
+    params.append("airt_target_model=TARGET_MODEL")
     canon = atk["canonical_name"]
-    if canon not in _ATTACKS_WITHOUT_AIRT_KWARGS:
-        params.append("airt_assessment_id=assessment.assessment_id")
-        params.append("airt_goal_category=GOAL_CATEGORY.value")
-        params.append("airt_target_model=TARGET_MODEL")
     attack_params = ",\n                ".join(params)
     assessment_name = _safe_str(config.get("assessment_name") or "{} Transform Comparison".format(canon))
     assessment_kwargs = _build_assessment_kwargs(config, assessment_name, config.get("filename", ""))
@@ -3601,17 +3580,6 @@ async def main():
                     sys.stdout.flush()
 
                     try:
-                        # Build airt_* kwargs only for attacks that accept them
-                        import inspect as _inspect
-                        _sig = _inspect.signature(attack_fn)
-                        _airt_kw = {{}}
-                        if "airt_assessment_id" in _sig.parameters:
-                            _airt_kw["airt_assessment_id"] = assessment.assessment_id
-                            _airt_kw["airt_goal_category"] = goal_cat.value
-                            _airt_kw["airt_category"] = goal_row.get("category", "")
-                            _airt_kw["airt_sub_category"] = goal_sub
-                            _airt_kw["airt_target_model"] = TARGET_MODEL
-
                         study = attack_fn(
                             {attack_params},
                         )
@@ -3753,9 +3721,12 @@ def _generate_category_attack(config: dict) -> str:
     if transforms:
         transforms_expr = "[{}]".format(", ".join(t["code"] for t in transforms))
         params.append("transforms={}".format(transforms_expr))
-    # Build airt_* kwargs dict conditionally — only pass to attacks that accept them.
-    # The template uses **_airt_kw which unpacks to nothing for unsupported attacks.
-    params.append("**_airt_kw")
+    # AIRT span linkage — all attacks accept these as of dreadnode-tiger#1693
+    params.append("airt_assessment_id=assessment.assessment_id")
+    params.append("airt_goal_category=goal_cat.value")
+    params.append("airt_category=goal_row.get('category', '')")
+    params.append("airt_sub_category=goal_sub")
+    params.append("airt_target_model=TARGET_MODEL")
     attack_params = ",\n                        ".join(params)
 
     transform_names = [t["resolved_name"] for t in transforms] if transforms else []

--- a/capabilities/ai-red-teaming/scripts/attack_runner.py
+++ b/capabilities/ai-red-teaming/scripts/attack_runner.py
@@ -95,7 +95,7 @@ def _resolve_platform_env() -> dict[str, str]:
     return env
 
 
-def _auto_execute_workflow(filename: str, timeout: int = 540) -> str:
+def _auto_execute_workflow(filename: str, timeout: int = 3600) -> str:
     """Execute a workflow script and return output. Used for auto-execution after generate."""
     filepath = WORKFLOWS_DIR / filename
     if not filepath.exists():

--- a/capabilities/ai-red-teaming/tools/attacks.py
+++ b/capabilities/ai-red-teaming/tools/attacks.py
@@ -42,7 +42,7 @@ def _call_runner(name: str, params: dict) -> str:
             input=payload,
             capture_output=True,
             text=True,
-            timeout=660,  # 11min: runner has 9min internal timeout + overhead
+            timeout=3660,  # 61min: runner has 60min internal timeout + overhead
         )
         output = result.stdout.strip()
         if result.returncode != 0:

--- a/capabilities/ai-red-teaming/tools/workflows.py
+++ b/capabilities/ai-red-teaming/tools/workflows.py
@@ -26,6 +26,36 @@ safe_tool = _errors_mod.safe_tool
 from dreadnode.app.env import resolve_python_executable
 
 
+def _resolve_platform_env() -> dict[str, str]:
+    """Build env dict with platform credentials for subprocess execution.
+
+    Mirrors attack_runner._resolve_platform_env so manually-executed
+    workflows get the same credential resolution as auto-executed ones.
+    """
+    env = os.environ.copy()
+    if env.get("DREADNODE_SERVER") and env.get("DREADNODE_API_KEY"):
+        return env
+    if env.get("DREADNODE_LLM_BASE") and env.get("DREADNODE_LLM_API_KEY"):
+        return env
+    try:
+        import yaml
+        config_path = Path.home() / ".dreadnode" / "config.yaml"
+        if config_path.exists():
+            config = yaml.safe_load(config_path.read_text())
+            active = config.get("active")
+            servers = config.get("servers", {})
+            if active and active in servers:
+                profile = servers[active]
+                env.setdefault("DREADNODE_SERVER", profile.get("url", ""))
+                env.setdefault("DREADNODE_API_KEY", profile.get("api_key", ""))
+                env.setdefault("DREADNODE_ORGANIZATION", profile.get("default_organization", ""))
+                env.setdefault("DREADNODE_WORKSPACE", profile.get("default_workspace", ""))
+                env.setdefault("DREADNODE_PROJECT", profile.get("default_project", ""))
+    except Exception:
+        pass
+    return env
+
+
 # Get org/workspace from active profile, with fallbacks
 def _get_workspace_path() -> Path:
     try:
@@ -165,7 +195,7 @@ def list_workflows() -> str:
 @safe_tool
 def execute_workflow(
     filename: t.Annotated[str, "Workflow filename to execute"],
-    timeout: t.Annotated[int, "Max execution time in seconds (max 600)"] = 540,
+    timeout: t.Annotated[int, "Max execution time in seconds (max 3600)"] = 540,
 ) -> str:
     """Execute a saved attack workflow script.
 
@@ -179,7 +209,7 @@ def execute_workflow(
     if not filepath.exists():
         return f"Workflow not found: {filename}. Use list_workflows to see available."
 
-    timeout = min(timeout, 600)
+    timeout = min(timeout, 3600)
 
     try:
         python_executable = resolve_python_executable()
@@ -193,6 +223,7 @@ def execute_workflow(
             text=True,
             timeout=timeout,
             cwd=str(WORKFLOWS_DIR.parent),
+            env=_resolve_platform_env(),
         )
         output = result.stdout
         if result.stderr:

--- a/capabilities/ai-red-teaming/tools/workflows.py
+++ b/capabilities/ai-red-teaming/tools/workflows.py
@@ -31,26 +31,26 @@ def _resolve_platform_env() -> dict[str, str]:
 
     Mirrors attack_runner._resolve_platform_env so manually-executed
     workflows get the same credential resolution as auto-executed ones.
+    Always reads the saved profile to fill org/workspace/project scope.
     """
     env = os.environ.copy()
-    if env.get("DREADNODE_SERVER") and env.get("DREADNODE_API_KEY"):
-        return env
-    if env.get("DREADNODE_LLM_BASE") and env.get("DREADNODE_LLM_API_KEY"):
-        return env
     try:
-        import yaml
-        config_path = Path.home() / ".dreadnode" / "config.yaml"
-        if config_path.exists():
-            config = yaml.safe_load(config_path.read_text())
-            active = config.get("active")
-            servers = config.get("servers", {})
-            if active and active in servers:
-                profile = servers[active]
-                env.setdefault("DREADNODE_SERVER", profile.get("url", ""))
-                env.setdefault("DREADNODE_API_KEY", profile.get("api_key", ""))
-                env.setdefault("DREADNODE_ORGANIZATION", profile.get("default_organization", ""))
-                env.setdefault("DREADNODE_WORKSPACE", profile.get("default_workspace", ""))
-                env.setdefault("DREADNODE_PROJECT", profile.get("default_project", ""))
+        from dreadnode.app.config import UserConfig
+
+        config = UserConfig.read()
+        profile_data = config.active_profile
+        if profile_data:
+            _, profile = profile_data
+            if profile.url:
+                env.setdefault("DREADNODE_SERVER", profile.url)
+            if profile.api_key:
+                env.setdefault("DREADNODE_API_KEY", profile.api_key)
+            if profile.organization:
+                env.setdefault("DREADNODE_ORGANIZATION", profile.organization)
+            if profile.workspace:
+                env.setdefault("DREADNODE_WORKSPACE", profile.workspace)
+            if profile.project:
+                env.setdefault("DREADNODE_PROJECT", profile.project)
     except Exception:
         pass
     return env


### PR DESCRIPTION
## Problem

When running a campaign with all 12 attack types against a target, 7 of 12 attacks crash with:
```
TypeError: rainbow_attack() got an unexpected keyword argument 'airt_assessment_id'
```

This affects: rainbow, gptfuzzer, autodan, renellm, beast, drattack, deep_inception (and hopskipjump, simba, nes, zoo, multimodal).

### Impact
- Campaigns with mixed attack types only partially complete
- User has to re-run failed attacks individually, creating **9 separate assessments** instead of 1
- Re-run attacks show **0 attacks** on the platform because they lack airt_* span linkage

## Root Cause

`_build_attack_params()` in `attack_runner.py` unconditionally injects `airt_assessment_id`, `airt_goal_category`, and `airt_target_model` into every generated attack call. However, only 34/46 SDK attacks accept these kwargs — the other 12 raise TypeError.

## Fix

1. **Added `_ATTACKS_WITHOUT_AIRT_KWARGS` set** — 12 attack functions that don't accept airt_* params (verified via SDK `inspect.signature()`)
2. **`_build_attack_params()`** — conditionally adds airt_* kwargs only for supported attacks
3. **`_generate_transform_study()`** — same conditional logic
4. **Category template** — uses runtime `inspect.signature()` check since attack functions are dispatched dynamically

## Testing

- `python3 -c` verification: campaign with tap+rainbow+beast generates correct kwargs per attack (tap gets airt_*, rainbow/beast don't)
- All existing unit tests pass
- Generated scripts compile without syntax errors

## Note for SDK team

Ideally all 46 attacks should accept airt_* kwargs for platform span linkage. The 12 attacks without support are the older/specialized ones. A follow-up SDK PR to add `**kwargs` or explicit airt_* params to all attacks would remove the need for this workaround.