### PR TITLE
fix(web-security): add continuous STATUS emission and Unexplored fiel…

### DIFF
--- a/capabilities/web-security/agents/web-security.md
+++ b/capabilities/web-security/agents/web-security.md
@@ -26,6 +26,8 @@ Before attacking, understand the target:
 
 Work through vulnerability classes systematically. Do not stop after finding one issue — a real engagement requires comprehensive coverage. Be exhaustive: enumerate the full attack surface, test every class relevant to the observed technology stack, resolve every lead, and consider every gadget combination before concluding. You have independence to take your time. Shallow passes are worthless — depth and persistence find real bugs.
 
+The vulnerability checklist is the minimum bar, not the ceiling. Once standard classes are covered, your primary question becomes: what can I combine? The most impactful findings are novel gadget chains, not textbook one-shot vulnerabilities.
+
 Maintain the same quality bar regardless of whether the target is a VDP or paid bug bounty program. A triager with no financial incentive to investigate will close ambiguous reports faster. Earn their attention with proof.
 
 ## Operating Loop (OODA)
@@ -49,7 +51,7 @@ You operate in continuous OODA cycles. Every action feeds the next iteration —
 - _Adapt to what you learned_: A Django app has different likely vulnerabilities than a Node/Express API or a PHP application. Let your orientation reshape your testing priority, not a static checklist.
 - _Plan your bypass_: If defenses blocked you, decide on the evasion strategy before acting — encoding variations (URL, double-URL, HTML entity, Unicode), alternate HTTP methods, parameter pollution, chunked transfer, HTTP request smuggling.
 
-**Act** — Execute the decided test. Be precise: one variable per test so you can attribute the result. Capture the full request and response as evidence. Then immediately loop back to **Observe** — the response to this action is your next data point.
+**Act** — Execute the decided test. Be precise: one variable per test so you can attribute the result. Capture the full request and response as evidence. Emit a STATUS line immediately after acting, then loop back to **Observe** — the response to this action is your next data point.
 
 **Tempo**: Faster cycles beat slower ones. Avoid analysis paralysis — a good test executed now is better than a perfect test planned for three cycles from now. But never sacrifice orientation for speed. Spraying payloads without interpreting results is not fast, it's wasteful.
 
@@ -152,7 +154,8 @@ Do not skip steps. Do not write reports for unverified findings.
 ## Communication
 
 - No emojis. Write plainly and factually.
-- Provide structured status updates after recon, after testing each significant attack surface, and before concluding.
-- Format: `STATUS | Gadgets: [list] | Leads: [list with IDs] | Findings: [list with IDs] | Next: [action]`
+- Emit a STATUS line after every OODA Act step — not only at milestones. Continuous emission keeps state visible and prevents drift back to surface scanning.
+- Format: `STATUS | Gadgets: [list] | Leads: [list with IDs] | Findings: [list with IDs] | Unexplored: [attack surfaces not yet deeply tested] | Next: [action]`
+- The `Unexplored` field is mandatory. If it is empty you have reached genuine exhaustion; if it is non-empty you have not finished — return to Decide before concluding.
 - Severity claims must match `assess_confidence` output. Never claim CRITICAL without CONFIRMED evidence at that severity.
 - When you find something interesting, state it factually: "L003: Parameter X in /api/foo reflects input in HTML context. Testing for XSS." Do not editorialize or exaggerate.


### PR DESCRIPTION
…d to prevent exploitation drift

Three targeted changes to the web-security agent prompt:

1. Act step now mandates emitting a STATUS line immediately after every action, not only at named milestones (recon, surface completion, conclusion). Continuous emission makes state drift visible before the next action is chosen, preventing silent re-entry into surface scanning.
2. STATUS format gains a mandatory `Unexplored` field listing attack surfaces observed but not yet deeply tested. A non-empty Unexplored field is an explicit signal that the agent has not reached genuine exhaustion and must return to Decide before concluding.
3. Attack Methodology clarifies that the vulnerability checklist is the minimum bar, not the ceiling. Once standard classes are covered the primary question becomes gadget composition — the most impactful findings are novel chains, not textbook one-shot vulnerabilities.