### PR TITLE
test(airt): guard generated workflows against dead Assessment methods (ENG-6777)

### DIFF
--- a/capabilities/ai-red-teaming/tests/test_attack_runner.py
+++ b/capabilities/ai-red-teaming/tests/test_attack_runner.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -487,3 +488,62 @@ class TestUniqueWorkflowPath:
 
         assert name == "a_v3.py"
         assert path == tmp_path / "a_v3.py"
+
+
+class TestGeneratedWorkflowAssessmentMethods:
+    """Generated workflows must only call methods that exist on the SDK
+    ``Assessment`` class (ENG-6777).
+
+    Older templates called ``assessment.record_attack()``, ``analyze()``,
+    ``push_analytics()``, ``generate_report()`` and ``push_report()`` — none
+    of which exist on the current ``Assessment`` — so the TUI's primary path
+    crashed with ``AttributeError`` on a fresh install. These tests guard
+    against that class of regression.
+    """
+
+    # The five methods named in the ticket that no longer exist.
+    DEAD_METHODS = (
+        "record_attack",
+        "analyze",
+        "push_analytics",
+        "generate_report",
+        "push_report",
+    )
+
+    def test_runner_source_has_no_dead_methods(self) -> None:
+        """No generator template (any mode) emits a dead Assessment call."""
+        source = RUNNER_PATH.read_text()
+        for method in self.DEAD_METHODS:
+            assert ".{}(".format(method) not in source, (
+                "attack_runner references removed Assessment method "
+                "'{}' — generated workflows will crash (ENG-6777)".format(method)
+            )
+
+    def _generate_script(self, tmp_path, monkeypatch, params: dict) -> str:
+        monkeypatch.setattr(runner, "WORKFLOWS_DIR", tmp_path)
+        result = runner.generate_attack({**params, "generate_only": True})
+        assert "error" not in result, result
+        return Path(result["filepath"]).read_text()
+
+    def test_single_attack_calls_exist_on_assessment(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Every ``assessment.<m>()`` in the template is a real Assessment attr.
+
+        Checks dynamically against the installed SDK so the test also fails if
+        the SDK renames/removes a method the template still relies on.
+        """
+        from dreadnode.airt.assessment import Assessment
+
+        script = self._generate_script(
+            tmp_path,
+            monkeypatch,
+            {"attack_type": "tap", "goal": "test", "target_model": "groq"},
+        )
+        called = set(re.findall(r"\bassessment\.(\w+)\s*\(", script))
+        assert called, "expected assessment.<method>() calls in generated script"
+        missing = sorted(m for m in called if not hasattr(Assessment, m))
+        assert not missing, (
+            "generated workflow calls Assessment methods that do not exist: "
+            "{}".format(missing)
+        )


### PR DESCRIPTION
Addresses [ENG-6777](https://linear.app/dreadnode/issue/ENG-6777/auto-generated-workflow-uses-non-existent-assessment-methods).

## Status: already fixed — this PR adds a regression guard

ENG-6777 reported that the TUI agent's `generate_attack` tool produced workflows calling `Assessment` methods that no longer exist (`record_attack`, `analyze`, `push_analytics`, `generate_report`, `push_report`), crashing the fresh-install happy path with `AttributeError`.

**Verified the current capability (1.4.0) no longer has this bug:**
- `Assessment` exposes only `register/trace/run/done/complete/fail`.
- `attack_runner.py` has zero references to the five methods (`git log -S record_attack` shows they never appear in tracked history — the rewrite to the `assessment.run(study)` API predates it).
- Generated a real `tap` workflow: it calls `register/trace/run/fail` only and executed to completion.

Since the code is already correct, this PR adds tests so the regression cannot silently return.

## Tests

- `test_runner_source_has_no_dead_methods` — no generator template (any of the 5 modes) references the removed methods.
- `test_single_attack_calls_exist_on_assessment` — extracts every `assessment.<m>()` call from a generated script and asserts each is a real attribute on the **installed SDK** `Assessment` class. This also catches the inverse: an SDK rename/removal of a method the template still uses.

Uses `generate_only: True` so generation runs without executing attacks (fast, offline).

## Test plan

- [x] `python -m pytest tests/test_attack_runner.py::TestGeneratedWorkflowAssessmentMethods` — 2 passed
- [x] Confirmed the dynamic check captures `register/trace/run/fail` and that all 5 dead methods report `hasattr=False`

No capability version bump — test-only, no behavioral change.