### PR TITLE
Bump network-ops to 1.0.2

### DIFF
--- a/capabilities/network-ops/capability.yaml
+++ b/capabilities/network-ops/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: network-ops
-version: "1.0.1"
+version: "1.0.2"
 description: >
   Network operations and Active Directory exploitation. Autonomous red
   teaming with Nmap scanning, Netexec enumeration, Impacket Kerberos


### PR DESCRIPTION
## Changed

- `network-ops` version bumped from `1.0.1` to `1.0.2` for tool wrapper bug fixes merged in #72