### PR TITLE
feat(airt): capture generated media output in multimodal workflows

### DIFF
--- a/capabilities/ai-red-teaming/capability.yaml
+++ b/capabilities/ai-red-teaming/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: ai-red-teaming
-version: "1.5.0"
+version: "1.6.0"
 description: >
   Probe the security and safety of AI applications, agents, and foundation models.
   Orchestrates adversarial attack workflows to discover vulnerabilities in LLMs,

--- a/capabilities/ai-red-teaming/scripts/attack_runner.py
+++ b/capabilities/ai-red-teaming/scripts/attack_runner.py
@@ -5150,19 +5150,34 @@ def _build_multimodal_imports(transforms: list[dict]) -> str:
 
 
 def _build_multimodal_target() -> str:
-    """A @task target that sends a multimodal Message to the target and returns text."""
+    """A @task target that sends a multimodal Message to the target.
+
+    Returns the model's full reply when it contains generated media
+    (image/audio/video) so those *output* parts are captured and rendered — e.g.
+    an image-out model or a speech-to-speech target. Otherwise returns the plain
+    text content, so text-out targets behave exactly as before.
+    """
     return """\
 @task
-async def target(message: Message) -> str:
+async def target(message: Message):
     generator = TARGET_GENERATOR
     last_error = None
+    _MEDIA_KINDS = {"image_url", "input_audio", "video_url"}
     for attempt in range(3):
         try:
             results = await generator.generate_messages([[message]], [GenerateParams()])
             if not results or isinstance(results[0], BaseException):
                 last_error = RuntimeError(f"Generator failed: {results[0] if results else 'No response'}")
                 continue
-            return results[0].message.content
+            reply = results[0].message
+            # Return the whole reply only when the model generated media, so the
+            # SDK captures the output image/audio/video parts. Plain text replies
+            # return `.content` (a str) — unchanged text-out behaviour.
+            has_media = any(
+                getattr(p, "type", None) in _MEDIA_KINDS
+                for p in (getattr(reply, "content_parts", None) or [])
+            )
+            return reply if has_media else reply.content
         except Exception as e:
             last_error = e
             if attempt < 2:

--- a/capabilities/ai-red-teaming/tests/test_attack_runner.py
+++ b/capabilities/ai-red-teaming/tests/test_attack_runner.py
@@ -590,6 +590,26 @@ class TestGenerateMultimodalAttack:
         assert "from dreadnode.transforms.image import add_gaussian_noise" in script
         assert "IMAGE_PATHS = ['/tmp/a.png', '/tmp/b.png']" in script
 
+    def test_target_captures_generated_media_output(self, tmp_path, monkeypatch) -> None:
+        """The generated target returns the model's full reply when it carries
+        generated media (image/audio/video), so output parts are captured for
+        media-out targets (e.g. image-out or speech-to-speech), while text-out
+        replies still return `.content`."""
+        res = self._gen(
+            tmp_path,
+            monkeypatch,
+            {
+                "goal": "g",
+                "target_model": "openai/gpt-4o",
+                "audio_paths": ["/tmp/a.wav"],
+            },
+        )
+        assert "error" not in res, res
+        script = Path(res["filepath"]).read_text()
+        compile(script, "multimodal.py", "exec")
+        assert '_MEDIA_KINDS = {"image_url", "input_audio", "video_url"}' in script
+        assert "return reply if has_media else reply.content" in script
+
     def test_image_dir_is_expanded(self, tmp_path, monkeypatch) -> None:
         media_dir = tmp_path / "imgs"
         media_dir.mkdir()


### PR DESCRIPTION
## Summary

Follow-up to the SDK multimodal-output work (dreadnode-tiger #1891). Enables the
platform-generated multimodal workflow to capture what a target **generates**,
not just what it says.

- The generated `@task target` now returns the model's **full reply** when it
  contains generated media (image / audio / video), so those output parts are
  captured and rendered in findings & traces. Plain text replies still return
  `.content` (a str), so text-out targets are **unchanged**.
- This is the piece that lets media-out targets flow through the capability UI:
  an image-out model, or a speech-to-speech target such as **Amazon Nova Sonic**
  driven via a custom target (audio-in → audio-out).
- Bumps capability `1.5.0` → `1.6.0`.

### Why this is safe
The change is gated on `content_parts` containing an image/audio/video kind.
Text-only replies take the identical `reply.content` path as before — no change
to the overwhelming majority (text-out) flow. Added a regression test asserting
both the media-kind guard and the text fallback.

### Sequencing
Merge alongside dreadnode-tiger #1891 (SDK: media-out `response_to_parts` +
per-modality scoring). The SDK's `response_to_parts` is what turns the returned
reply into typed output parts. Per-modality **scoring** of generated media is a
separate future step (the current `llm_judge` stringifies its input, so it can't
yet judge a generated image/audio — that needs a multimodal judge scorer).

## Test plan
- [x] `pytest capabilities/ai-red-teaming/tests/test_attack_runner.py` — all pass
- [x] `pytest tests/test_capability_release_plan.py` — passes with 1.6.0
- [ ] Post-merge: run a media-out target through the capability, confirm output
      image/audio/video renders & plays in Overview + Traces