### PR TITLE
chore(web-security): bump version to 1.2.0

### DIFF
--- a/capabilities/web-security/capability.yaml
+++ b/capabilities/web-security/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: web-security
-version: "1.1.6"
+version: "1.2.0"
 description: >
   Web application penetration testing with 60+ attack technique playbooks
   covering request smuggling, cache poisoning, SSRF, SSTI, DOM

--- a/capabilities/web-security/capability.yaml
+++ b/capabilities/web-security/capability.yaml
@@ -2,16 +2,22 @@ schema: 1
 name: web-security
 version: "1.2.0"
 description: >
-  Web application penetration testing with 60+ attack technique playbooks
+  Web application penetration testing with 70+ attack technique playbooks
   covering request smuggling, cache poisoning, SSRF, SSTI, DOM
   vulnerabilities, authentication bypasses, parser differentials,
-  AEM/Sling exploitation, and client-side attacks. Includes HTTP client
-  tooling, Caido proxy integration via MCP, credential management, DNS
-  rebinding, AWS exploitation with Pacu, phone verification,
-  vulnerability verification, IP rotation helpers (Flareprox, fireprox),
-  archive extraction vulnerability crafting with archivealchemist,
-  EXIF metadata manipulation via exiftool, and AgentMail email inboxes
-  for agent-owned signup, recovery, and verification flows.
+  AEM/Sling exploitation, GraphQL, OAuth, and client-side attacks.
+  Includes HTTP client tooling with OOB callbacks via interactsh, Caido
+  and Burp proxy integration via MCP, browser automation via
+  agent-browser, JS static analysis via jxscout, protobuf inspection via
+  protoscope, credential management, DNS rebinding, blind SQLi
+  extraction, bug bounty scope lookup via bbscope, HackerOne program
+  recon and report submission, SecurityContext vulnerability context
+  from GitHub repos, issue tracking via Jira/GitHub/Linear, AWS
+  exploitation with Pacu, phone verification, vulnerability
+  verification, IP rotation helpers (Flareprox, fireprox), archive
+  extraction vulnerability crafting with archivealchemist, EXIF
+  metadata manipulation via exiftool, and AgentMail email inboxes for
+  agent-owned signup, recovery, and verification flows.
 
 produces:
   values: [finding, asset]
@@ -109,6 +115,7 @@ dependencies:
     - "httpx>=0.28"
     - "caido-sdk-client"
     - "cryptography>=41.0"
+    - "pydantic>=2.0"
   scripts:
     - scripts/install_tools.sh
 
@@ -165,3 +172,24 @@ keywords:
   - archive-extraction
   - zip-slip
   - path-traversal
+  - sql-injection
+  - blind-sqli
+  - xss
+  - ssrf
+  - ssti
+  - graphql
+  - oauth
+  - hackerone
+  - bbscope
+  - jira
+  - github
+  - linear
+  - protoscope
+  - protobuf
+  - agent-browser
+  - browser-automation
+  - burp-suite
+  - jxscout
+  - interactsh
+  - oob-callbacks
+  - securitycontext


### PR DESCRIPTION
## Summary

Bump web-security from `1.1.6` → `1.2.0` to reconcile the published capability with the actual state of main.

## Problem

The platform is serving v1.1.12, which was synced from the closed evidence_hooks branch ([PR #55](https://github.com/dreadnode/capabilities/pull/55)). That branch was missing content that's on main:

- `tools/agentmail.py` (PR #85)
- `tools/blind_sqli.py` + `skills/blind-sqli-extraction/`
- `mcp/securitycontext.py`
- `items.py` (structured findings via `produces`)
- `skills/caido-sdk/`, `skills/git-integration-exploitation/`, `skills/http-query-method/`

## This PR

One-line version bump. Main already has the correct, complete content — no evidence_guard or browser_js_proof (those PRs were closed). Pushing this will trigger the CI sync to publish v1.2.0 with the clean state of main.

## Test plan

- [x] `capability.yaml` validates
- [ ] CI sync publishes 1.2.0 to dev/staging/prod