### PR TITLE
feat(ai-red-teaming): expose 167 multimodal transforms to the TUI (v1.7.0)

### DIFF
--- a/capabilities/ai-red-teaming/agents/ai-red-teaming-agent.md
+++ b/capabilities/ai-red-teaming/agents/ai-red-teaming-agent.md
@@ -526,15 +526,20 @@ hand-written SDK `@task` target; recommend the SDK path and score its audio repl
 
 Map the user's intent (or the SOTA technique) to concrete transforms:
 
+Over 130 modality-typed image/audio/video transforms are available (see the multimodal
+docs for the full reference); the highest-value mappings:
+
 | Technique (SOTA) | What it does | Transforms |
 |------------------|--------------|-----------|
-| Typographic / image-as-instruction (FigStep, MM-SafetyBench) | Render the payload as pixels to bypass text filters | `add_text_overlay('…')`, `overlay_emoji` |
-| Visual prompt injection | Hide instructions in a benign image | `add_text_overlay`, `image_steganography` |
-| Cross-modal steganography | Embed instructions in pixels/bits | `image_steganography` |
-| Adversarial perturbation (HADES, image hijacks) | Perturb pixels to redirect attention | `add_gaussian_noise`, `add_laplace_noise`, `shift_pixel_values` |
-| Robustness / evasion under distortion | Test safety under common corruptions | `blur`, `jpeg_compression`, `pixelate`, `rotate`, `grayscale` |
-| Audio jailbreak / vishing (AdvWave, AudioJailbreak) | Perturb or distort the spoken prompt | `add_white_noise`, `pitch_shift`, `time_stretch`, `change_speed` |
-| Video frame injection / subliminal | Inject an attack frame into video | `video_frame_inject`, `subliminal_frame` |
+| Typographic / image-as-instruction (FigStep, MM-SafetyBench) | Render the payload as pixels to bypass text filters | `figstep_image('…')`, `typographic_prompt('…')`, `add_text_overlay('…')`, `meme_format('…')` |
+| Visual prompt injection | Hide instructions in a benign image | `add_text_overlay`, `adversarial_patch('…')`, `overlay_stripes` |
+| Cross-modal steganography | Embed instructions in pixels/bits | `image_steganography`, `audio_steganography`, `video_frame_inject` |
+| Adversarial perturbation (HADES, image hijacks) | Perturb pixels to redirect attention | `add_gaussian_noise`, `high_frequency_perturbation`, `chromatic_aberration`, `elastic_deform` |
+| Robustness / evasion under distortion (ImageNet-C) | Test safety under common corruptions | `blur`, `jpeg_compression`, `pixelate`, `defocus_blur`, `glass_blur`, `zoom_blur`, `fog`, `snow`, `spatter`, `motion_blur` |
+| Audio jailbreak / inaudible commands (DolphinAttack, AdvWave, AudioJailbreak) | Perturb, hide, or distort the spoken prompt | `ultrasonic_shift`, `spectral_inversion`, `audio_steganography`, `time_masking`, `frequency_masking`, `pitch_shift`, `add_babble_noise` |
+| Audio robustness / channel simulation | Test safety over degraded audio channels | `downsample_telephone`, `ogg_codec_roundtrip`, `air_absorption`, `add_reverb`, `sample_dropout`, `bit_crush` |
+| Video frame injection / subliminal | Inject or distribute an attack across frames | `video_frame_inject`, `subliminal_frame`, `keyframe_replace('…')`, `scene_cut_inject('…')`, `per_frame_text_scroll('…')`, `strobe` |
+| Temporal / sparse-sampling video attacks | Exploit frame sampling and temporal ordering | `temporal_shuffle`, `frame_dropout`, `frame_rate_down`, `ghost_overlay('…')`, `motion_smear` |
 
 Text transforms (see Transform Catalog) also apply — they transform the prompt while media
 transforms transform the media; the SDK routes each by its modality. Benchmarks to anchor

--- a/capabilities/ai-red-teaming/agents/ai-red-teaming-agent.md
+++ b/capabilities/ai-red-teaming/agents/ai-red-teaming-agent.md
@@ -526,7 +526,7 @@ hand-written SDK `@task` target; recommend the SDK path and score its audio repl
 
 Map the user's intent (or the SOTA technique) to concrete transforms:
 
-Over 130 modality-typed image/audio/video transforms are available (see the multimodal
+Over 160 modality-typed image/audio/video transforms are available (see the multimodal
 docs for the full reference); the highest-value mappings:
 
 | Technique (SOTA) | What it does | Transforms |

--- a/capabilities/ai-red-teaming/capability.yaml
+++ b/capabilities/ai-red-teaming/capability.yaml
@@ -9,10 +9,10 @@ description: >
   prompt injection, data exfiltration, tool manipulation, reasoning attacks, guardrail
   bypass, and more — mapped to OWASP LLM Top 10, OWASP ASI01-ASI10, MITRE ATLAS,
   and NIST AI RMF compliance frameworks. 45 attack algorithms (41 LLM + 4 adversarial
-  ML samplers), 500+ transforms (including 130+ image/audio/video multimodal
-  perturbations spanning AugLy, ImageNet-C, SpecAugment, and published multimodal
-  jailbreak families), an extensive scorer catalog, and 260 bundled harm goals
-  across 25 sub-categories in safety, security, and agentic tiers.
+  ML samplers), 500+ transforms (including 160+ image/audio/video multimodal
+  perturbations spanning AugLy, Albumentations, ImageNet-C, SpecAugment, and
+  published multimodal jailbreak families), an extensive scorer catalog, and 260
+  bundled harm goals across 25 sub-categories in safety, security, and agentic tiers.
 
 agents:
   - agents/

--- a/capabilities/ai-red-teaming/capability.yaml
+++ b/capabilities/ai-red-teaming/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: ai-red-teaming
-version: "1.6.10"
+version: "1.7.0"
 description: >
   Probe the security and safety of AI applications, agents, and foundation models.
   Orchestrates adversarial attack workflows to discover vulnerabilities in LLMs,
@@ -9,8 +9,10 @@ description: >
   prompt injection, data exfiltration, tool manipulation, reasoning attacks, guardrail
   bypass, and more — mapped to OWASP LLM Top 10, OWASP ASI01-ASI10, MITRE ATLAS,
   and NIST AI RMF compliance frameworks. 45 attack algorithms (41 LLM + 4 adversarial
-  ML samplers), 500+ transforms, an extensive scorer catalog, and 260 bundled harm
-  goals across 25 sub-categories in safety, security, and agentic tiers.
+  ML samplers), 500+ transforms (including 130+ image/audio/video multimodal
+  perturbations spanning AugLy, ImageNet-C, SpecAugment, and published multimodal
+  jailbreak families), an extensive scorer catalog, and 260 bundled harm goals
+  across 25 sub-categories in safety, security, and agentic tiers.
 
 agents:
   - agents/

--- a/capabilities/ai-red-teaming/scripts/attack_runner.py
+++ b/capabilities/ai-red-teaming/scripts/attack_runner.py
@@ -5124,37 +5124,48 @@ _MULTIMODAL_GOAL_CATEGORIES = {
 # Modality-typed transforms for multimodal red teaming. The SDK routes each by
 # its `modality` attribute (image/audio/video), so image transforms only touch
 # the image, audio only the audio, etc. Text transforms fall back to the main
-# registry via _resolve_multimodal_transform().
+# registry via _resolve_multimodal_transform(). Names mirror the SDK factories in
+# dreadnode.transforms.{image,audio,video}; see the multimodal docs for the full
+# reference. Transforms needing non-string args (interpolate_images, overlay_image,
+# frames_from_image_transform) are SDK-only and intentionally not exposed here.
+_IMAGE_TRANSFORMS: list[str] = [
+    "add_gaussian_noise", "add_laplace_noise", "add_uniform_noise", "shift_pixel_values",
+    "add_text_overlay", "image_steganography", "blur", "adjust_brightness", "adjust_contrast",
+    "adjust_saturation", "rotate", "horizontal_flip", "vertical_flip", "jpeg_compression",
+    "pixelate", "grayscale", "overlay_emoji", "crop", "pad", "color_jitter", "shuffle_pixels",
+    "solarize", "posterize", "invert_colors", "adversarial_patch", "sharpen",
+    "salt_pepper_noise", "motion_blur", "cutout", "channel_shuffle", "hue_shift",
+    "chromatic_aberration", "perspective_warp", "elastic_deform", "halftone_dither",
+    "histogram_equalize", "autocontrast", "downscale", "high_frequency_perturbation", "sepia",
+    "change_aspect_ratio", "skew", "meme_format", "opacity_blend", "overlay_stripes",
+    "pad_square", "shot_noise", "speckle_noise", "defocus_blur", "glass_blur", "zoom_blur",
+    "fog", "snow", "spatter", "apply_pil_filter", "figstep_image", "typographic_prompt",
+]
+_AUDIO_TRANSFORMS: list[str] = [
+    "add_white_noise", "add_pink_noise", "change_volume", "normalize_volume", "change_speed",
+    "time_stretch", "pitch_shift", "apply_low_pass_filter", "apply_high_pass_filter",
+    "apply_band_pass_filter", "add_reverb", "add_echo", "apply_dynamic_range_compression",
+    "add_clipping", "trim_silence", "add_fade", "ultrasonic_shift", "spectral_inversion",
+    "bit_crush", "add_tone", "audio_steganography", "add_brown_noise", "add_babble_noise",
+    "add_clicks", "time_masking", "frequency_masking", "reverse_audio", "tremolo", "vibrato",
+    "wow_flutter", "granular_shuffle", "sample_dropout", "pre_emphasis", "notch_filter",
+    "peaking_equalizer", "soft_clip", "ring_modulation", "downsample_telephone", "loop_audio",
+    "polarity_inversion", "time_shift", "gain_transition", "air_absorption",
+    "low_shelf_filter", "high_shelf_filter", "band_stop_filter", "seven_band_parametric_eq",
+    "aliasing", "limiter", "add_short_noises", "repeat_part", "ogg_codec_roundtrip",
+]
+_VIDEO_TRANSFORMS: list[str] = [
+    "video_frame_inject", "video_metadata_inject", "subliminal_frame",
+    "frame_brightness_flicker", "temporal_shuffle", "frame_dropout", "keyframe_replace",
+    "per_frame_text_scroll", "frame_reverse", "freeze_frame", "loop_frames", "frame_rate_up",
+    "frame_rate_down", "scene_cut_inject", "strobe", "replace_with_color_frames",
+    "ghost_overlay", "letterbox_caption", "rolling_temporal_jitter", "motion_smear",
+    "frame_interpolate_blend", "temporal_noise",
+]
 _MULTIMODAL_TRANSFORM_DEFS: dict[str, dict] = {
-    # Image (dreadnode.transforms.image)
-    "add_gaussian_noise": {"module": "dreadnode.transforms.image", "name": "add_gaussian_noise"},
-    "add_laplace_noise": {"module": "dreadnode.transforms.image", "name": "add_laplace_noise"},
-    "add_uniform_noise": {"module": "dreadnode.transforms.image", "name": "add_uniform_noise"},
-    "shift_pixel_values": {"module": "dreadnode.transforms.image", "name": "shift_pixel_values"},
-    "add_text_overlay": {"module": "dreadnode.transforms.image", "name": "add_text_overlay"},
-    "image_steganography": {"module": "dreadnode.transforms.image", "name": "image_steganography"},
-    "blur": {"module": "dreadnode.transforms.image", "name": "blur"},
-    "adjust_brightness": {"module": "dreadnode.transforms.image", "name": "adjust_brightness"},
-    "adjust_contrast": {"module": "dreadnode.transforms.image", "name": "adjust_contrast"},
-    "rotate": {"module": "dreadnode.transforms.image", "name": "rotate"},
-    "horizontal_flip": {"module": "dreadnode.transforms.image", "name": "horizontal_flip"},
-    "vertical_flip": {"module": "dreadnode.transforms.image", "name": "vertical_flip"},
-    "jpeg_compression": {"module": "dreadnode.transforms.image", "name": "jpeg_compression"},
-    "pixelate": {"module": "dreadnode.transforms.image", "name": "pixelate"},
-    "grayscale": {"module": "dreadnode.transforms.image", "name": "grayscale"},
-    "overlay_emoji": {"module": "dreadnode.transforms.image", "name": "overlay_emoji"},
-    # Audio (dreadnode.transforms.audio)
-    "add_white_noise": {"module": "dreadnode.transforms.audio", "name": "add_white_noise"},
-    "add_pink_noise": {"module": "dreadnode.transforms.audio", "name": "add_pink_noise"},
-    "change_volume": {"module": "dreadnode.transforms.audio", "name": "change_volume"},
-    "change_speed": {"module": "dreadnode.transforms.audio", "name": "change_speed"},
-    "time_stretch": {"module": "dreadnode.transforms.audio", "name": "time_stretch"},
-    "pitch_shift": {"module": "dreadnode.transforms.audio", "name": "pitch_shift"},
-    "apply_low_pass_filter": {"module": "dreadnode.transforms.audio", "name": "apply_low_pass_filter"},
-    # Video (dreadnode.transforms.video)
-    "video_frame_inject": {"module": "dreadnode.transforms.video", "name": "video_frame_inject"},
-    "video_metadata_inject": {"module": "dreadnode.transforms.video", "name": "video_metadata_inject"},
-    "subliminal_frame": {"module": "dreadnode.transforms.video", "name": "subliminal_frame"},
+    **{n: {"module": "dreadnode.transforms.image", "name": n} for n in _IMAGE_TRANSFORMS},
+    **{n: {"module": "dreadnode.transforms.audio", "name": n} for n in _AUDIO_TRANSFORMS},
+    **{n: {"module": "dreadnode.transforms.video", "name": n} for n in _VIDEO_TRANSFORMS},
 }
 
 

--- a/capabilities/ai-red-teaming/scripts/attack_runner.py
+++ b/capabilities/ai-red-teaming/scripts/attack_runner.py
@@ -5140,6 +5140,7 @@ _IMAGE_TRANSFORMS: list[str] = [
     "change_aspect_ratio", "skew", "meme_format", "opacity_blend", "overlay_stripes",
     "pad_square", "shot_noise", "speckle_noise", "defocus_blur", "glass_blur", "zoom_blur",
     "fog", "snow", "spatter", "apply_pil_filter", "figstep_image", "typographic_prompt",
+    "invisible_text",
     "median_blur", "gamma_correction", "color_quantize", "ordered_dither", "vignette",
     "rgb_shift", "channel_dropout", "hsv_shift", "coarse_dropout", "pixel_dropout",
     "morphology", "optical_distortion", "grid_distortion", "rain", "random_shadow",

--- a/capabilities/ai-red-teaming/scripts/attack_runner.py
+++ b/capabilities/ai-red-teaming/scripts/attack_runner.py
@@ -5140,6 +5140,10 @@ _IMAGE_TRANSFORMS: list[str] = [
     "change_aspect_ratio", "skew", "meme_format", "opacity_blend", "overlay_stripes",
     "pad_square", "shot_noise", "speckle_noise", "defocus_blur", "glass_blur", "zoom_blur",
     "fog", "snow", "spatter", "apply_pil_filter", "figstep_image", "typographic_prompt",
+    "median_blur", "gamma_correction", "color_quantize", "ordered_dither", "vignette",
+    "rgb_shift", "channel_dropout", "hsv_shift", "coarse_dropout", "pixel_dropout",
+    "morphology", "optical_distortion", "grid_distortion", "rain", "random_shadow",
+    "iso_noise", "ringing_overshoot", "fancy_pca", "webp_compression", "affine",
 ]
 _AUDIO_TRANSFORMS: list[str] = [
     "add_white_noise", "add_pink_noise", "change_volume", "normalize_volume", "change_speed",
@@ -5152,7 +5156,9 @@ _AUDIO_TRANSFORMS: list[str] = [
     "peaking_equalizer", "soft_clip", "ring_modulation", "downsample_telephone", "loop_audio",
     "polarity_inversion", "time_shift", "gain_transition", "air_absorption",
     "low_shelf_filter", "high_shelf_filter", "band_stop_filter", "seven_band_parametric_eq",
-    "aliasing", "limiter", "add_short_noises", "repeat_part", "ogg_codec_roundtrip",
+    "aliasing", "limiter", "add_short_noises", "repeat_part", "ogg_codec_roundtrip", "chorus",
+    "flanger", "harmonic_distortion", "dc_offset", "adjust_duration", "apply_impulse_response",
+    "dtmf_tone", "reverse_segments", "loudness_normalize",
 ]
 _VIDEO_TRANSFORMS: list[str] = [
     "video_frame_inject", "video_metadata_inject", "subliminal_frame",
@@ -5160,7 +5166,8 @@ _VIDEO_TRANSFORMS: list[str] = [
     "per_frame_text_scroll", "frame_reverse", "freeze_frame", "loop_frames", "frame_rate_up",
     "frame_rate_down", "scene_cut_inject", "strobe", "replace_with_color_frames",
     "ghost_overlay", "letterbox_caption", "rolling_temporal_jitter", "motion_smear",
-    "frame_interpolate_blend", "temporal_noise",
+    "frame_interpolate_blend", "temporal_noise", "frame_jitter", "color_flicker", "stutter",
+    "reverse_frame_segments", "speed_ramp", "pip_inject",
 ]
 _MULTIMODAL_TRANSFORM_DEFS: dict[str, dict] = {
     **{n: {"module": "dreadnode.transforms.image", "name": n} for n in _IMAGE_TRANSFORMS},

--- a/capabilities/ai-red-teaming/tools/attacks.py
+++ b/capabilities/ai-red-teaming/tools/attacks.py
@@ -426,9 +426,13 @@ def generate_multimodal_attack(
         list[str] | None,
         "Modality-typed transforms applied per attack. Image: add_gaussian_noise, "
         "add_text_overlay('PWNED'), image_steganography, blur, rotate, jpeg_compression, "
-        "overlay_emoji. Audio: add_white_noise, pitch_shift, time_stretch, change_speed. "
-        "Video: video_frame_inject, subliminal_frame. Text transforms also work (applied "
-        "to the prompt). The SDK routes each by modality.",
+        "overlay_emoji, solarize, posterize, invert_colors, adversarial_patch('IGNORE'), "
+        "shuffle_pixels, color_jitter. Audio: add_white_noise, pitch_shift, time_stretch, "
+        "change_speed, add_reverb, add_echo, apply_band_pass_filter, ultrasonic_shift, "
+        "spectral_inversion, bit_crush, add_tone, audio_steganography('PWNED'). Video: "
+        "video_frame_inject, subliminal_frame, frame_brightness_flicker, temporal_shuffle, "
+        "frame_dropout, keyframe_replace('INJECT'), per_frame_text_scroll('secret'). Text "
+        "transforms also work (applied to the prompt). The SDK routes each by modality.",
     ] = None,
     judge_model: t.Annotated[
         str,


### PR DESCRIPTION
## Summary

Registers the full SDK image/audio/video transform catalog in the multimodal transform resolver so TUI / `attack_runner` attacks can apply any of them by name. Exposed media transforms grow from **26 → 131** (image 57, audio 52, video 22).

This is the capability-side companion to dreadnode-tiger **#1954**, which adds the 130+ transform implementations to the SDK. Once both land and the capability publishes, TUI operators can request the new transforms directly (e.g. "apply `figstep_image` and `fog` to the image", "add `ultrasonic_shift` and `frequency_masking` to the audio").

## Changes
- **`scripts/attack_runner.py`** — rebuild `_MULTIMODAL_TRANSFORM_DEFS` from per-modality name lists mirroring `dreadnode.transforms.{image,audio,video}`. SDK-only transforms needing non-string args (`interpolate_images`, `overlay_image`, `frames_from_image_transform`) are intentionally excluded.
- **`tools/attacks.py`** — refresh the `transforms` parameter examples across all three modalities.
- **`agents/ai-red-teaming-agent.md`** — expand the attack technique → transform map with ImageNet-C corruptions, SpecAugment masking, DolphinAttack-style covert audio, and temporal/sparse-sampling video attacks; note 130+ multimodal transforms.
- **`capability.yaml`** — minor version bump **1.6.10 → 1.7.0**; description notes 130+ image/audio/video perturbations spanning AugLy, ImageNet-C, SpecAugment, and published multimodal jailbreak families.

## Test plan
- [x] `attack_runner.py` parses (AST); `_MULTIMODAL_TRANSFORM_DEFS` builds to **131 entries** (image 57, audio 52, video 22)
- [x] Registered names mirror the SDK factory names exactly (verified against `dreadnode.transforms.*`)
- [ ] Sync Capabilities CI green