### PR TITLE
fix(web-security): finalize produces item schemas so report_item builds

### DIFF
--- a/capabilities/web-security/items.py
+++ b/capabilities/web-security/items.py
@@ -363,3 +363,33 @@ class WebEndpoint(BaseModel):
             "'openapi_spec_url', 'rate_limited'."
         ),
     )
+
+
+# ---------------------------------------------------------------------------
+# Forward-reference finalization
+# ---------------------------------------------------------------------------
+#
+# This module uses ``from __future__ import annotations`` (PEP 563), so every
+# field annotation is stored as a string and resolved lazily on first schema
+# build. The Dreadnode capability loader and OCI packager import this file by
+# path (``importlib.util.spec_from_file_location`` + ``exec_module``) WITHOUT
+# registering it in ``sys.modules``. In that state, Pydantic's deferred
+# forward-reference resolution cannot locate this module's namespace, so the
+# first ``model_json_schema()`` call — which the ``report_item`` tool build and
+# the package builder both make — raises ``PydanticUserError: ... is not fully
+# defined``. That failure is swallowed upstream, silently dropping the typed
+# ``report_item`` tool and every structured output type this capability
+# declares in ``produces``.
+#
+# Rebuilding each model here, at module scope, resolves every forward reference
+# against this module's globals while they are still in scope — independent of
+# how the module was imported. The loop covers all models defined above and any
+# added later, so new types are finalized automatically with no extra wiring.
+for _model in list(globals().values()):
+    if (
+        isinstance(_model, type)
+        and issubclass(_model, BaseModel)
+        and _model is not BaseModel
+    ):
+        _model.model_rebuild()
+del _model

--- a/capabilities/web-security/tests/test_items_produces.py
+++ b/capabilities/web-security/tests/test_items_produces.py
@@ -1,0 +1,104 @@
+"""Regression tests for structured ``produces`` item schemas (CAP-1152).
+
+The web-security manifest declares custom structured output types via
+``produces`` (``web_vulnerability`` / ``web_endpoint``) plus the built-in
+``finding`` / ``asset`` types. The Dreadnode capability loader and the OCI
+packager import ``items.py`` by path **without** registering it in
+``sys.modules`` and then call ``model_json_schema()``. Because ``items.py``
+uses ``from __future__ import annotations`` (PEP 563), Pydantic must resolve
+forward references lazily — which fails in that unregistered-module state
+unless the models are rebuilt at import time.
+
+These tests reproduce the loader's exact import path and assert that every
+declared model produces a JSON schema, guaranteeing the typed ``report_item``
+tool (and the published package schemas) build cleanly.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+ITEMS_PATH = (Path(__file__).resolve().parent.parent / "items.py").resolve()
+
+# Types the manifest's `produces:` block references by "module:Class".
+PRODUCED_MODELS = ("WebVulnerability", "WebEndpoint")
+
+
+def _load_items_like_the_loader():
+    """Import items.py exactly the way the SDK loader/packager does.
+
+    ``spec_from_file_location`` + ``module_from_spec`` + ``exec_module`` with
+    NO ``sys.modules`` registration and a unique module name — the precise
+    conditions under which the forward-reference bug manifests.
+    """
+    mod_name = "_dn_test_web_security_items_cap1152"
+    sys.modules.pop(mod_name, None)
+    spec = importlib.util.spec_from_file_location(mod_name, ITEMS_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Intentionally NOT added to sys.modules — matches report_items.py and oci.py.
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_items_file_exists():
+    assert ITEMS_PATH.is_file(), f"items.py not found at {ITEMS_PATH}"
+
+
+@pytest.mark.parametrize("class_name", PRODUCED_MODELS)
+def test_produced_model_schema_builds_under_loader_import(class_name):
+    """Each `produces`-referenced model must yield a JSON schema when imported
+    the way the loader does. This is the exact call that previously raised
+    ``PydanticUserError: ... is not fully defined``."""
+    module = _load_items_like_the_loader()
+    model = getattr(module, class_name)
+    schema = model.model_json_schema()
+    assert schema["type"] == "object"
+    assert "properties" in schema
+
+
+def test_all_module_models_are_fully_defined():
+    """Scalable guard: every BaseModel subclass defined in items.py must build
+    a schema — so newly added types can never silently regress."""
+    module = _load_items_like_the_loader()
+    models = [
+        obj
+        for obj in vars(module).values()
+        if isinstance(obj, type)
+        and issubclass(obj, BaseModel)
+        and obj is not BaseModel
+        and obj.__module__ == module.__name__
+    ]
+    assert models, "expected at least one BaseModel defined in items.py"
+    for model in models:
+        schema = model.model_json_schema()  # must not raise
+        assert schema["type"] == "object"
+
+
+def test_severity_forward_reference_resolves():
+    """WebVulnerability.severity uses the module-level ``Severity`` literal — the
+    forward reference that triggered the original failure. Confirm it resolved
+    to the expected enum values in the built schema."""
+    module = _load_items_like_the_loader()
+    schema = module.WebVulnerability.model_json_schema()
+    # `severity` is required and enumerates the Severity literal values.
+    props = schema["properties"]
+    assert "severity" in props
+    flat = str(props["severity"])
+    for value in ("critical", "high", "medium", "low", "informational"):
+        assert value in flat
+
+
+def test_nested_cvss_models_resolve():
+    """Nested optional CVSS models must also resolve under the loader import."""
+    module = _load_items_like_the_loader()
+    schema = module.WebVulnerability.model_json_schema()
+    # $defs should include the nested CVSS model schemas.
+    defs = schema.get("$defs", {})
+    assert "CvssV31" in defs
+    assert "CvssV40" in defs


### PR DESCRIPTION
## Problem

The web-security manifest declares structured output types via `produces:`
(`web_vulnerability`, `web_endpoint`, plus built-in `finding`/`asset`), but in
production the typed `report_item` tool was **never offered to the agent** — it
silently fell back to the generic `report` tool, so no structured findings
appeared in the app.

Confirmed in session `0896781d-1f46-4726-ba02-596c3051eb39`: 6 `report` calls,
zero `report_item` calls, zero structured items emitted.

## Root cause

`items.py` uses `from __future__ import annotations` (PEP 563), so field
annotations like `severity: Severity` are stored as strings and resolved
lazily. The SDK capability loader and OCI packager import `items.py` by path
(`spec_from_file_location` + `exec_module`) **without** registering it in
`sys.modules`. In that state Pydantic cannot resolve the `Severity` forward
reference, so the first `model_json_schema()` call — made by both the
`report_item` tool build and the package builder — raises
`PydanticUserError: ... is not fully defined`. That error is swallowed
upstream, dropping the entire `report_item` / `update_item` / `link_items`
tool set.

## Fix

Rebuild every `BaseModel` at module scope so forward references resolve against
the module globals regardless of how the file is imported. The loop covers all
current models and any added later — KISS and self-maintaining, no per-model
wiring.

## Testing (against the real installed SDK, dreadnode 2.0.33)

- runtime resolver `_resolve_produces_models` imports both custom models
- `build_capability_report_item` yields item_type enum
  `{finding, asset, web_vulnerability, web_endpoint}`
- build-time `_resolve_produced_item_types` embeds both JSON schemas
- negative control: without the fix, `model_json_schema()` fails as reported
- new `tests/test_items_produces.py` (6 tests) reproduces the loader's exact
  import path and asserts every declared model builds a schema
- `dreadnode capability validate --strict` passes (only unrelated caido/burp
  binary warnings)

## Note: complementary SDK bug (tracked separately)

The SDK capability loader (`_parse_capability_file`) does not thread `produces`
(or legacy `items`) into `CapabilityManifest`, and the loader/packager omit
`sys.modules` registration before `exec_module`. This capability-side fix is
necessary and correct, but full publish-path coverage also needs the SDK
change. Filed internally.
