### PR TITLE
Ensure impacket importable in runtime Python

### DIFF
--- a/capabilities/network-ops/capability.yaml
+++ b/capabilities/network-ops/capability.yaml
@@ -35,6 +35,8 @@ dependencies:
     - scripts/install_coercion_tools.sh
 
 checks:
+  - name: impacket
+    command: "python3 -c 'import impacket' 2>/dev/null"
   - name: nmap
     command: "command -v nmap >/dev/null 2>&1"
   - name: petitpotam

--- a/capabilities/network-ops/capability.yaml
+++ b/capabilities/network-ops/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: network-ops
-version: "2.1.0"
+version: "2.1.1"
 description: >
   Network operations and Active Directory exploitation. Multi-agent
   pipeline for autonomous red teaming with Nmap scanning, Netexec

--- a/capabilities/network-ops/scripts/install_coercion_tools.sh
+++ b/capabilities/network-ops/scripts/install_coercion_tools.sh
@@ -8,8 +8,8 @@ set -euo pipefail
 # runtime Python can't import impacket, install it explicitly.
 if ! python3 -c "import impacket" 2>/dev/null; then
     echo "[+] Installing impacket into runtime Python"
-    pip install --quiet "impacket>=0.12.0" 2>/dev/null \
-        || pip install --quiet --break-system-packages "impacket>=0.12.0"
+    python3 -m pip install --quiet "impacket>=0.12.0" 2>/dev/null \
+        || python3 -m pip install --quiet --break-system-packages "impacket>=0.12.0"
 else
     echo "[*] impacket already importable, skipping"
 fi

--- a/capabilities/network-ops/scripts/install_coercion_tools.sh
+++ b/capabilities/network-ops/scripts/install_coercion_tools.sh
@@ -1,8 +1,20 @@
 #!/usr/bin/env bash
-# Install coercion scripts for NTLM relay attacks.
+# Install dependencies for the network-ops capability.
 # Runs at sandbox provision time via dependencies.scripts.
 set -euo pipefail
 
+# -- Impacket (ensure it's importable by the runtime Python) ----------------
+# dependencies.python should handle this, but belt-and-suspenders: if the
+# runtime Python can't import impacket, install it explicitly.
+if ! python3 -c "import impacket" 2>/dev/null; then
+    echo "[+] Installing impacket into runtime Python"
+    pip install --quiet "impacket>=0.12.0" 2>/dev/null \
+        || pip install --quiet --break-system-packages "impacket>=0.12.0"
+else
+    echo "[*] impacket already importable, skipping"
+fi
+
+# -- Coercion scripts -------------------------------------------------------
 REPOS=(
     "https://github.com/topotam/PetitPotam /opt/PetitPotam"
     "https://github.com/Wh04m1001/DFSCoerce /opt/DFSCoerce"


### PR DESCRIPTION
Agent session  on v2.1.0 still hit `ModuleNotFoundError: No module named 'impacket'` — the runtime didn't process `dependencies.python` for the file-synced capability.

## Fixed

- Impacket tools (`lookupsid`, `wmiexec`, `secretsdump`, etc.) no longer fail when the runtime skips `dependencies.python` — the install script now checks `python3 -c "import impacket"` and pip-installs it as a fallback

## Added

- Readiness check for `impacket` in `capability.yaml` so the capability warns at load time if impacket is missing