### PR TITLE
Auto-install impacket at tool import time

### DIFF
--- a/capabilities/network-ops/capability.yaml
+++ b/capabilities/network-ops/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: network-ops
-version: "2.1.1"
+version: "2.1.2"
 description: >
   Network operations and Active Directory exploitation. Multi-agent
   pipeline for autonomous red teaming with Nmap scanning, Netexec

--- a/capabilities/network-ops/scripts/install_coercion_tools.sh
+++ b/capabilities/network-ops/scripts/install_coercion_tools.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # runtime Python can't import impacket, install it explicitly.
 if ! python3 -c "import impacket" 2>/dev/null; then
     echo "[+] Installing impacket into runtime Python"
-    python3 -m pip install --quiet "impacket>=0.12.0" 2>/dev/null \
+    python3 -m pip install --quiet "impacket>=0.12.0" \
         || python3 -m pip install --quiet --break-system-packages "impacket>=0.12.0"
 else
     echo "[*] impacket already importable, skipping"

--- a/capabilities/network-ops/tools/impacket.py
+++ b/capabilities/network-ops/tools/impacket.py
@@ -66,7 +66,12 @@ def _ensure_impacket_installed() -> None:
     The runtime may not process ``dependencies.python`` from
     ``capability.yaml``, so we do a best-effort pip install at import
     time as a fallback.
+
+    Set ``DREADNODE_SKIP_AUTO_INSTALL=1`` to disable (useful in tests/CI).
     """
+    if os.environ.get("DREADNODE_SKIP_AUTO_INSTALL", "").strip() in ("1", "true", "yes"):
+        return
+
     try:
         import impacket as _  # noqa: F401
     except ImportError:
@@ -75,7 +80,7 @@ def _ensure_impacket_installed() -> None:
         logger.warning("impacket not importable — attempting pip install")
         for extra_args in ([], ["--break-system-packages"]):
             try:
-                subprocess.check_call(
+                subprocess.run(
                     [
                         sys.executable,
                         "-m",
@@ -87,10 +92,12 @@ def _ensure_impacket_installed() -> None:
                     ],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
+                    check=True,
+                    timeout=120,
                 )
                 logger.info("impacket installed successfully")
                 return
-            except subprocess.CalledProcessError:
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError):
                 continue
         logger.error("Failed to install impacket — impacket tools will not work")
 

--- a/capabilities/network-ops/tools/impacket.py
+++ b/capabilities/network-ops/tools/impacket.py
@@ -60,6 +60,36 @@ def _extract_real_path_from_wrapper(wrapper_path: Path) -> Path | None:
     return None
 
 
+def _ensure_impacket_installed() -> None:
+    """Install impacket into the running Python if it's not importable.
+
+    The runtime may not process ``dependencies.python`` from
+    ``capability.yaml``, so we do a best-effort pip install at import
+    time as a fallback.
+    """
+    try:
+        import impacket as _  # noqa: F401
+    except ImportError:
+        import subprocess
+
+        logger.warning("impacket not importable — attempting pip install")
+        for extra_args in ([], ["--break-system-packages"]):
+            try:
+                subprocess.check_call(
+                    [sys.executable, "-m", "pip", "install", "--quiet", "impacket>=0.12.0", *extra_args],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                logger.info("impacket installed successfully")
+                return
+            except subprocess.CalledProcessError:
+                continue
+        logger.error("Failed to install impacket — impacket tools will not work")
+
+
+_ensure_impacket_installed()
+
+
 def _get_impacket_script_path() -> Path:
     """
     Auto-discover the impacket scripts directory.

--- a/capabilities/network-ops/tools/impacket.py
+++ b/capabilities/network-ops/tools/impacket.py
@@ -76,7 +76,15 @@ def _ensure_impacket_installed() -> None:
         for extra_args in ([], ["--break-system-packages"]):
             try:
                 subprocess.check_call(
-                    [sys.executable, "-m", "pip", "install", "--quiet", "impacket>=0.12.0", *extra_args],
+                    [
+                        sys.executable,
+                        "-m",
+                        "pip",
+                        "install",
+                        "--quiet",
+                        "impacket>=0.12.0",
+                        *extra_args,
+                    ],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                 )


### PR DESCRIPTION
Runtime doesn't process `dependencies.python` or run `dependencies.scripts` — confirmed across three agent sessions where impacket tools fail with `ModuleNotFoundError` despite capability v2.1.1 being loaded.

## Fixed

- Impacket tools no longer fail with `ModuleNotFoundError` on runtimes that skip `dependencies.python` — `_ensure_impacket_installed()` runs at module import and pip-installs impacket via `sys.executable -m pip` if `import impacket` fails