### PR TITLE
Remove unsupported target_ip from atexec and dcomexec

### DIFF
--- a/capabilities/network-ops/capability.yaml
+++ b/capabilities/network-ops/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: network-ops
-version: "2.1.3"
+version: "2.1.4"
 description: >
   Network operations and Active Directory exploitation. Multi-agent
   pipeline for autonomous red teaming with Nmap scanning, Netexec

--- a/capabilities/network-ops/scripts/install_coercion_tools.sh
+++ b/capabilities/network-ops/scripts/install_coercion_tools.sh
@@ -14,6 +14,33 @@ else
     echo "[*] impacket already importable, skipping"
 fi
 
+# -- OpenSSL legacy provider (MD4 for NTLM) ---------------------------------
+# Modern OpenSSL disables MD4, breaking impacket tools that compute NTLM hashes
+# (rbcd, dacledit, owneredit, and any NTLM password auth path).
+# Enable the legacy provider if the config exists and isn't already patched.
+OPENSSL_CONF="$(openssl version -d 2>/dev/null | sed 's/.*"\(.*\)"/\1/')/openssl.cnf"
+if [ -f "$OPENSSL_CONF" ] && ! grep -q "^\[legacy_sect\]" "$OPENSSL_CONF" 2>/dev/null; then
+    echo "[+] Enabling OpenSSL legacy provider for MD4 support"
+    cat >> "$OPENSSL_CONF" <<'LEGACY'
+
+# Enable legacy provider for MD4 (required by impacket NTLM)
+[provider_sect]
+default = default_sect
+legacy = legacy_sect
+
+[default_sect]
+activate = 1
+
+[legacy_sect]
+activate = 1
+LEGACY
+    echo "[*] OpenSSL legacy provider enabled"
+elif [ -f "$OPENSSL_CONF" ]; then
+    echo "[*] OpenSSL legacy provider already configured, skipping"
+else
+    echo "[!] OpenSSL config not found at $OPENSSL_CONF, skipping MD4 fix"
+fi
+
 # -- Coercion scripts -------------------------------------------------------
 REPOS=(
     "https://github.com/topotam/PetitPotam /opt/PetitPotam"

--- a/capabilities/network-ops/scripts/install_coercion_tools.sh
+++ b/capabilities/network-ops/scripts/install_coercion_tools.sh
@@ -14,33 +14,6 @@ else
     echo "[*] impacket already importable, skipping"
 fi
 
-# -- OpenSSL legacy provider (MD4 for NTLM) ---------------------------------
-# Modern OpenSSL disables MD4, breaking impacket tools that compute NTLM hashes
-# (rbcd, dacledit, owneredit, and any NTLM password auth path).
-# Enable the legacy provider if the config exists and isn't already patched.
-OPENSSL_CONF="$(openssl version -d 2>/dev/null | sed 's/.*"\(.*\)"/\1/')/openssl.cnf"
-if [ -f "$OPENSSL_CONF" ] && ! grep -q "^\[legacy_sect\]" "$OPENSSL_CONF" 2>/dev/null; then
-    echo "[+] Enabling OpenSSL legacy provider for MD4 support"
-    cat >> "$OPENSSL_CONF" <<'LEGACY'
-
-# Enable legacy provider for MD4 (required by impacket NTLM)
-[provider_sect]
-default = default_sect
-legacy = legacy_sect
-
-[default_sect]
-activate = 1
-
-[legacy_sect]
-activate = 1
-LEGACY
-    echo "[*] OpenSSL legacy provider enabled"
-elif [ -f "$OPENSSL_CONF" ]; then
-    echo "[*] OpenSSL legacy provider already configured, skipping"
-else
-    echo "[!] OpenSSL config not found at $OPENSSL_CONF, skipping MD4 fix"
-fi
-
 # -- Coercion scripts -------------------------------------------------------
 REPOS=(
     "https://github.com/topotam/PetitPotam /opt/PetitPotam"

--- a/capabilities/network-ops/tools/impacket.py
+++ b/capabilities/network-ops/tools/impacket.py
@@ -4018,7 +4018,6 @@ class Impacket(Toolset):
         kerberos: bool = False,
         aes_key: str | None = None,
         dc_ip: str | None = None,
-        target_ip: str | None = None,
         session_id: int | None = None,
         codec: str | None = None,
         timeout: int | None = None,
@@ -4066,11 +4065,11 @@ class Impacket(Toolset):
 
         connection:
         -dc-ip ip address     IP Address of the domain controller.
-        -target-ip ip address IP Address of the target machine.
         </documentation>
 
         Args:
-            target: Target hostname or IP address (required).
+            target: Target hostname or IP address (required). Use the IP
+                directly if DNS resolution is unavailable.
             command: Command to execute on the remote host (required).
             domain: Domain name.
             username: Username for authentication.
@@ -4079,7 +4078,6 @@ class Impacket(Toolset):
             kerberos: Use Kerberos authentication.
             aes_key: AES key for Kerberos authentication.
             dc_ip: Domain controller IP address override.
-            target_ip: Target machine IP address override.
             session_id: Existing logon session ID to use (no output mode).
             codec: Output encoding codec.
             timeout: Command timeout in seconds.
@@ -4102,7 +4100,7 @@ class Impacket(Toolset):
                 hashes=hashes, kerberos=kerberos, aes_key=aes_key, password=password
             )
         )
-        args.extend(self._build_connection_flags(dc_ip=dc_ip, target_ip=target_ip))
+        args.extend(self._build_connection_flags(dc_ip=dc_ip))
 
         return await execute(
             self._build_script_command("atexec.py", args),
@@ -4124,7 +4122,6 @@ class Impacket(Toolset):
         kerberos: bool = False,
         aes_key: str | None = None,
         dc_ip: str | None = None,
-        target_ip: str | None = None,
         share: str | None = None,
         dcom_object: str | None = None,
         shell_type: str | None = None,
@@ -4190,11 +4187,11 @@ class Impacket(Toolset):
 
         connection:
         -dc-ip ip address     IP Address of the domain controller.
-        -target-ip ip address IP Address of the target machine.
         </documentation>
 
         Args:
-            target: Target hostname or IP address (required).
+            target: Target hostname or IP address (required). Use the IP
+                directly if DNS resolution is unavailable.
             command: Command to execute. If empty, returns shell banner.
             domain: Domain name.
             username: Username for authentication.
@@ -4203,7 +4200,6 @@ class Impacket(Toolset):
             kerberos: Use Kerberos authentication.
             aes_key: AES key for Kerberos authentication.
             dc_ip: Domain controller IP address override.
-            target_ip: Target machine IP address override.
             share: Share where output is grabbed from (default ADMIN$).
             dcom_object: DCOM object — 'MMC20', 'ShellWindows', or 'ShellBrowserWindow'.
             shell_type: Command processor — 'cmd' or 'powershell'.
@@ -4237,7 +4233,7 @@ class Impacket(Toolset):
                 hashes=hashes, kerberos=kerberos, aes_key=aes_key, password=password
             )
         )
-        args.extend(self._build_connection_flags(dc_ip=dc_ip, target_ip=target_ip))
+        args.extend(self._build_connection_flags(dc_ip=dc_ip))
 
         # If no command given, send exit to prevent interactive shell hang
         effective_input = input if command else (input or "exit\n")


### PR DESCRIPTION
Fixes tool argument compatibility issue found during agent testing.

## Breaking

- **`impacket_atexec` and `impacket_dcomexec` no longer accept `target_ip`** — impacket 0.13.x doesn't support `-target-ip` for these scripts (wmiexec, psexec, smbexec still support it). Use the IP directly as `target` instead.
