### PR TITLE
Use uv pip install for runtime venvs without pip

### DIFF
--- a/capabilities/network-ops/capability.yaml
+++ b/capabilities/network-ops/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: network-ops
-version: "2.1.4"
+version: "2.1.5"
 description: >
   Network operations and Active Directory exploitation. Multi-agent
   pipeline for autonomous red teaming with Nmap scanning, Netexec
@@ -35,8 +35,6 @@ dependencies:
     - scripts/install_coercion_tools.sh
 
 checks:
-  - name: impacket
-    command: "python3 -c 'import impacket' 2>/dev/null"
   - name: nmap
     command: "command -v nmap >/dev/null 2>&1"
   - name: petitpotam

--- a/capabilities/network-ops/tools/impacket.py
+++ b/capabilities/network-ops/tools/impacket.py
@@ -91,20 +91,35 @@ def _ensure_impacket_installed() -> None:
         pass
 
     logger.warning(
-        f"impacket not importable by {sys.executable} — attempting pip install"
+        f"impacket not importable by {sys.executable} — attempting install"
     )
-    for extra_args in ([], ["--break-system-packages"]):
+
+    # Build install commands to try in order:
+    # 1. uv pip install --python (works in uv venvs that lack pip)
+    # 2. sys.executable -m pip install (works in standard venvs)
+    # 3. sys.executable -m pip install --break-system-packages (externally managed)
+    install_cmds: list[list[str]] = []
+
+    uv = shutil.which("uv")
+    if uv:
+        install_cmds.append(
+            [uv, "pip", "install", "--python", sys.executable, "impacket>=0.12.0"]
+        )
+
+    install_cmds.append(
+        [sys.executable, "-m", "pip", "install", "--quiet", "impacket>=0.12.0"]
+    )
+    install_cmds.append(
+        [
+            sys.executable, "-m", "pip", "install", "--quiet",
+            "--break-system-packages", "impacket>=0.12.0",
+        ]
+    )
+
+    for cmd in install_cmds:
         try:
             subprocess.run(
-                [
-                    sys.executable,
-                    "-m",
-                    "pip",
-                    "install",
-                    "--quiet",
-                    "impacket>=0.12.0",
-                    *extra_args,
-                ],
+                cmd,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 check=True,


### PR DESCRIPTION
The runtime Python is a uv-managed venv with `include-system-site-packages = false` and no pip module. `_ensure_impacket_installed()` tried `sys.executable -m pip install` which always failed silently.

## Fixed

- `_ensure_impacket_installed()` now tries `uv pip install --python <sys.executable>` first, which works in uv venvs that lack pip, then falls back to `sys.executable -m pip` for standard venvs
- Removed misleading impacket readiness check from `capability.yaml` — it tested system `python3` (3.13) not the runtime Python (3.12), always passing even when broken

## Notes

- Bug 1 from the report (`dreadnode/capabilities/install.py` not passing `--python` to `uv pip install`) is a platform-side issue, not fixable here