### PR TITLE
Provision wordlists for password cracking at install time

### DIFF
--- a/capabilities/network-ops/capability.yaml
+++ b/capabilities/network-ops/capability.yaml
@@ -44,7 +44,7 @@ checks:
   - name: shadowcoerce
     command: "test -f /opt/ShadowCoerce/shadowcoerce.py"
   - name: rockyou-wordlist
-    command: "test -f /usr/share/wordlists/rockyou.txt"
+    command: "test -s /usr/share/wordlists/rockyou.txt"
 
 keywords:
   - network-ops

--- a/capabilities/network-ops/capability.yaml
+++ b/capabilities/network-ops/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: network-ops
-version: "2.1.6"
+version: "2.1.7"
 description: >
   Network operations and Active Directory exploitation. Multi-agent
   pipeline for autonomous red teaming with Nmap scanning, Netexec
@@ -43,6 +43,8 @@ checks:
     command: "test -f /opt/DFSCoerce/dfscoerce.py"
   - name: shadowcoerce
     command: "test -f /opt/ShadowCoerce/shadowcoerce.py"
+  - name: rockyou-wordlist
+    command: "test -f /usr/share/wordlists/rockyou.txt"
 
 keywords:
   - network-ops

--- a/capabilities/network-ops/scripts/install_coercion_tools.sh
+++ b/capabilities/network-ops/scripts/install_coercion_tools.sh
@@ -26,7 +26,7 @@ elif [ -f "$WORDLIST_DIR/rockyou.txt.gz" ]; then
     gunzip -k "$WORDLIST_DIR/rockyou.txt.gz"
 else
     echo "[+] Downloading rockyou.txt"
-    curl -fsSL "https://github.com/brannondorsey/naive-hashcat/releases/download/data/rockyou.txt" \
+    curl -fsSL --retry 3 "https://github.com/brannondorsey/naive-hashcat/releases/download/data/rockyou.txt" \
         -o "$WORDLIST_DIR/rockyou.txt"
 fi
 
@@ -35,19 +35,19 @@ if [ -f "$WORDLIST_DIR/10k-most-common.txt" ]; then
     echo "[*] 10k-most-common.txt already exists, skipping"
 else
     echo "[+] Downloading SecLists 10k most common passwords"
-    curl -fsSL "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Passwords/Common-Credentials/10k-most-common.txt" \
+    curl -fsSL --retry 3 "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Passwords/Common-Credentials/10k-most-common.txt" \
         -o "$WORDLIST_DIR/10k-most-common.txt"
 fi
 
 # OneRuleToRuleThemAll — hashcat rules that multiply wordlist effectiveness
 # Combines rules from Hob0Rules, KoreLogic, NSA, and hashcat generated rules
 RULES_DIR="/usr/share/hashcat/rules"
-if [ -d "$RULES_DIR" ] || mkdir -p "$RULES_DIR" 2>/dev/null; then
+if [ -d "$RULES_DIR" ] || mkdir -p "$RULES_DIR"; then
     if [ -f "$RULES_DIR/OneRuleToRuleThemAll.rule" ]; then
         echo "[*] OneRuleToRuleThemAll.rule already exists, skipping"
     else
         echo "[+] Downloading OneRuleToRuleThemAll hashcat rules"
-        curl -fsSL "https://raw.githubusercontent.com/NotSoSecure/password_cracking_rules/master/OneRuleToRuleThemAll.rule" \
+        curl -fsSL --retry 3 "https://raw.githubusercontent.com/NotSoSecure/password_cracking_rules/master/OneRuleToRuleThemAll.rule" \
             -o "$RULES_DIR/OneRuleToRuleThemAll.rule"
     fi
 fi

--- a/capabilities/network-ops/scripts/install_coercion_tools.sh
+++ b/capabilities/network-ops/scripts/install_coercion_tools.sh
@@ -24,33 +24,41 @@ if [ -s "$WORDLIST_DIR/rockyou.txt" ]; then
 elif [ -f "$WORDLIST_DIR/rockyou.txt.gz" ]; then
     echo "[+] Decompressing rockyou.txt.gz"
     rm -f "$WORDLIST_DIR/rockyou.txt"
-    gunzip -k "$WORDLIST_DIR/rockyou.txt.gz"
+    gunzip -k "$WORDLIST_DIR/rockyou.txt.gz" \
+        || echo "[!] Failed to decompress rockyou.txt.gz (non-fatal)"
 else
     echo "[+] Downloading rockyou.txt"
     curl -fsSL --retry 3 --connect-timeout 10 "https://github.com/brannondorsey/naive-hashcat/releases/download/data/rockyou.txt" \
-        -o "$WORDLIST_DIR/rockyou.txt"
+        -o "$WORDLIST_DIR/rockyou.txt" \
+        || echo "[!] Failed to download rockyou.txt (non-fatal)"
 fi
 
 # Top 10k most common passwords — fast first-pass for spraying
+# Non-fatal: wordlist download failures shouldn't block coercion script setup
 if [ -s "$WORDLIST_DIR/10k-most-common.txt" ]; then
     echo "[*] 10k-most-common.txt already exists, skipping"
 else
     echo "[+] Downloading SecLists 10k most common passwords"
     curl -fsSL --retry 3 --connect-timeout 10 "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Passwords/Common-Credentials/10k-most-common.txt" \
-        -o "$WORDLIST_DIR/10k-most-common.txt"
+        -o "$WORDLIST_DIR/10k-most-common.txt" \
+        || echo "[!] Failed to download 10k-most-common.txt (non-fatal)"
 fi
 
 # OneRuleToRuleThemAll — hashcat rules that multiply wordlist effectiveness
 # Combines rules from Hob0Rules, KoreLogic, NSA, and hashcat generated rules
+# Non-fatal: rules dir may not be writable and that's OK
 RULES_DIR="/usr/share/hashcat/rules"
-if [ -d "$RULES_DIR" ] || mkdir -p "$RULES_DIR"; then
+if mkdir -p "$RULES_DIR" 2>/dev/null; then
     if [ -s "$RULES_DIR/OneRuleToRuleThemAll.rule" ]; then
         echo "[*] OneRuleToRuleThemAll.rule already exists, skipping"
     else
         echo "[+] Downloading OneRuleToRuleThemAll hashcat rules"
         curl -fsSL --retry 3 --connect-timeout 10 "https://raw.githubusercontent.com/NotSoSecure/password_cracking_rules/master/OneRuleToRuleThemAll.rule" \
-            -o "$RULES_DIR/OneRuleToRuleThemAll.rule"
+            -o "$RULES_DIR/OneRuleToRuleThemAll.rule" \
+            || echo "[!] Failed to download OneRuleToRuleThemAll.rule (non-fatal)"
     fi
+else
+    echo "[!] Cannot create $RULES_DIR (non-fatal, skipping hashcat rules)"
 fi
 
 # -- Coercion scripts -------------------------------------------------------

--- a/capabilities/network-ops/scripts/install_coercion_tools.sh
+++ b/capabilities/network-ops/scripts/install_coercion_tools.sh
@@ -48,7 +48,7 @@ fi
 # Combines rules from Hob0Rules, KoreLogic, NSA, and hashcat generated rules
 # Non-fatal: rules dir may not be writable and that's OK
 RULES_DIR="/usr/share/hashcat/rules"
-if mkdir -p "$RULES_DIR" 2>/dev/null; then
+if mkdir -p "$RULES_DIR" 2>&1; then
     if [ -s "$RULES_DIR/OneRuleToRuleThemAll.rule" ]; then
         echo "[*] OneRuleToRuleThemAll.rule already exists, skipping"
     else

--- a/capabilities/network-ops/scripts/install_coercion_tools.sh
+++ b/capabilities/network-ops/scripts/install_coercion_tools.sh
@@ -14,6 +14,40 @@ else
     echo "[*] impacket already importable, skipping"
 fi
 
+# -- Wordlists for password cracking -----------------------------------------
+WORDLIST_DIR="/usr/share/wordlists"
+mkdir -p "$WORDLIST_DIR"
+
+# rockyou — the standard first-pass wordlist (14M passwords)
+if [ -f "$WORDLIST_DIR/rockyou.txt" ]; then
+    echo "[*] rockyou.txt already exists, skipping"
+elif [ -f "$WORDLIST_DIR/rockyou.txt.gz" ]; then
+    echo "[+] Decompressing rockyou.txt.gz"
+    gunzip -k "$WORDLIST_DIR/rockyou.txt.gz"
+else
+    echo "[+] Downloading rockyou.txt"
+    curl -fsSL "https://github.com/brannondorsey/naive-hashcat/releases/download/data/rockyou.txt" \
+        -o "$WORDLIST_DIR/rockyou.txt"
+fi
+
+# SecLists common passwords (top 1M, good for spraying/fast cracks)
+if [ -f "$WORDLIST_DIR/10-million-password-list-top-1000000.txt" ]; then
+    echo "[*] SecLists top-1M already exists, skipping"
+else
+    echo "[+] Downloading SecLists top-1M password list"
+    curl -fsSL "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Passwords/Common-Credentials/10-million-password-list-top-1000000.txt" \
+        -o "$WORDLIST_DIR/10-million-password-list-top-1000000.txt"
+fi
+
+# SecLists common usernames (for user enumeration / spraying)
+if [ -f "$WORDLIST_DIR/xato-net-10-million-usernames.txt" ]; then
+    echo "[*] SecLists usernames already exists, skipping"
+else
+    echo "[+] Downloading SecLists username list"
+    curl -fsSL "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Usernames/xato-net-10-million-usernames.txt" \
+        -o "$WORDLIST_DIR/xato-net-10-million-usernames.txt"
+fi
+
 # -- Coercion scripts -------------------------------------------------------
 REPOS=(
     "https://github.com/topotam/PetitPotam /opt/PetitPotam"

--- a/capabilities/network-ops/scripts/install_coercion_tools.sh
+++ b/capabilities/network-ops/scripts/install_coercion_tools.sh
@@ -18,7 +18,7 @@ fi
 WORDLIST_DIR="/usr/share/wordlists"
 mkdir -p "$WORDLIST_DIR"
 
-# rockyou — the standard first-pass wordlist (14M passwords)
+# rockyou — the standard wordlist for cracking (14M passwords)
 if [ -f "$WORDLIST_DIR/rockyou.txt" ]; then
     echo "[*] rockyou.txt already exists, skipping"
 elif [ -f "$WORDLIST_DIR/rockyou.txt.gz" ]; then
@@ -30,22 +30,26 @@ else
         -o "$WORDLIST_DIR/rockyou.txt"
 fi
 
-# SecLists common passwords (top 1M, good for spraying/fast cracks)
-if [ -f "$WORDLIST_DIR/10-million-password-list-top-1000000.txt" ]; then
-    echo "[*] SecLists top-1M already exists, skipping"
+# Top 10k most common passwords — fast first-pass for spraying
+if [ -f "$WORDLIST_DIR/10k-most-common.txt" ]; then
+    echo "[*] 10k-most-common.txt already exists, skipping"
 else
-    echo "[+] Downloading SecLists top-1M password list"
-    curl -fsSL "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Passwords/Common-Credentials/10-million-password-list-top-1000000.txt" \
-        -o "$WORDLIST_DIR/10-million-password-list-top-1000000.txt"
+    echo "[+] Downloading SecLists 10k most common passwords"
+    curl -fsSL "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Passwords/Common-Credentials/10k-most-common.txt" \
+        -o "$WORDLIST_DIR/10k-most-common.txt"
 fi
 
-# SecLists common usernames (for user enumeration / spraying)
-if [ -f "$WORDLIST_DIR/xato-net-10-million-usernames.txt" ]; then
-    echo "[*] SecLists usernames already exists, skipping"
-else
-    echo "[+] Downloading SecLists username list"
-    curl -fsSL "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Usernames/xato-net-10-million-usernames.txt" \
-        -o "$WORDLIST_DIR/xato-net-10-million-usernames.txt"
+# OneRuleToRuleThemAll — hashcat rules that multiply wordlist effectiveness
+# Combines rules from Hob0Rules, KoreLogic, NSA, and hashcat generated rules
+RULES_DIR="/usr/share/hashcat/rules"
+if [ -d "$RULES_DIR" ] || mkdir -p "$RULES_DIR" 2>/dev/null; then
+    if [ -f "$RULES_DIR/OneRuleToRuleThemAll.rule" ]; then
+        echo "[*] OneRuleToRuleThemAll.rule already exists, skipping"
+    else
+        echo "[+] Downloading OneRuleToRuleThemAll hashcat rules"
+        curl -fsSL "https://raw.githubusercontent.com/NotSoSecure/password_cracking_rules/master/OneRuleToRuleThemAll.rule" \
+            -o "$RULES_DIR/OneRuleToRuleThemAll.rule"
+    fi
 fi
 
 # -- Coercion scripts -------------------------------------------------------

--- a/capabilities/network-ops/scripts/install_coercion_tools.sh
+++ b/capabilities/network-ops/scripts/install_coercion_tools.sh
@@ -19,23 +19,23 @@ WORDLIST_DIR="/usr/share/wordlists"
 mkdir -p "$WORDLIST_DIR"
 
 # rockyou — the standard wordlist for cracking (14M passwords)
-if [ -f "$WORDLIST_DIR/rockyou.txt" ]; then
+if [ -s "$WORDLIST_DIR/rockyou.txt" ]; then
     echo "[*] rockyou.txt already exists, skipping"
 elif [ -f "$WORDLIST_DIR/rockyou.txt.gz" ]; then
     echo "[+] Decompressing rockyou.txt.gz"
     gunzip -k "$WORDLIST_DIR/rockyou.txt.gz"
 else
     echo "[+] Downloading rockyou.txt"
-    curl -fsSL --retry 3 "https://github.com/brannondorsey/naive-hashcat/releases/download/data/rockyou.txt" \
+    curl -fsSL --retry 3 --connect-timeout 10 "https://github.com/brannondorsey/naive-hashcat/releases/download/data/rockyou.txt" \
         -o "$WORDLIST_DIR/rockyou.txt"
 fi
 
 # Top 10k most common passwords — fast first-pass for spraying
-if [ -f "$WORDLIST_DIR/10k-most-common.txt" ]; then
+if [ -s "$WORDLIST_DIR/10k-most-common.txt" ]; then
     echo "[*] 10k-most-common.txt already exists, skipping"
 else
     echo "[+] Downloading SecLists 10k most common passwords"
-    curl -fsSL --retry 3 "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Passwords/Common-Credentials/10k-most-common.txt" \
+    curl -fsSL --retry 3 --connect-timeout 10 "https://raw.githubusercontent.com/danielmiessler/SecLists/master/Passwords/Common-Credentials/10k-most-common.txt" \
         -o "$WORDLIST_DIR/10k-most-common.txt"
 fi
 
@@ -43,11 +43,11 @@ fi
 # Combines rules from Hob0Rules, KoreLogic, NSA, and hashcat generated rules
 RULES_DIR="/usr/share/hashcat/rules"
 if [ -d "$RULES_DIR" ] || mkdir -p "$RULES_DIR"; then
-    if [ -f "$RULES_DIR/OneRuleToRuleThemAll.rule" ]; then
+    if [ -s "$RULES_DIR/OneRuleToRuleThemAll.rule" ]; then
         echo "[*] OneRuleToRuleThemAll.rule already exists, skipping"
     else
         echo "[+] Downloading OneRuleToRuleThemAll hashcat rules"
-        curl -fsSL --retry 3 "https://raw.githubusercontent.com/NotSoSecure/password_cracking_rules/master/OneRuleToRuleThemAll.rule" \
+        curl -fsSL --retry 3 --connect-timeout 10 "https://raw.githubusercontent.com/NotSoSecure/password_cracking_rules/master/OneRuleToRuleThemAll.rule" \
             -o "$RULES_DIR/OneRuleToRuleThemAll.rule"
     fi
 fi

--- a/capabilities/network-ops/scripts/install_coercion_tools.sh
+++ b/capabilities/network-ops/scripts/install_coercion_tools.sh
@@ -23,6 +23,7 @@ if [ -s "$WORDLIST_DIR/rockyou.txt" ]; then
     echo "[*] rockyou.txt already exists, skipping"
 elif [ -f "$WORDLIST_DIR/rockyou.txt.gz" ]; then
     echo "[+] Decompressing rockyou.txt.gz"
+    rm -f "$WORDLIST_DIR/rockyou.txt"
     gunzip -k "$WORDLIST_DIR/rockyou.txt.gz"
 else
     echo "[+] Downloading rockyou.txt"


### PR DESCRIPTION
Hashcat and john_the_ripper default to `/usr/share/wordlists/rockyou.txt` which doesn't exist on the runtime.

## Added

- Install script downloads `rockyou.txt` (14M passwords), SecLists `10k-most-common.txt` (fast spraying), and `OneRuleToRuleThemAll.rule` (hashcat rules) at provision time
- Handles Kali's pre-existing `rockyou.txt.gz` by decompressing instead of re-downloading
- Readiness check for `rockyou.txt`
- All downloads use `curl --retry 3` for transient network resilience