### PR TITLE
fix(ai-red-teaming): import get_generator in generated ATLAS script

### DIFF
--- a/capabilities/ai-red-teaming/scripts/attack_runner.py
+++ b/capabilities/ai-red-teaming/scripts/attack_runner.py
@@ -4701,6 +4701,7 @@ def _build_atlas_imports() -> str:
             "from pathlib import Path",
             "",
             "import dreadnode as dn",
+            "from dreadnode.generators.generator import get_generator, GenerateParams",
             "from dreadnode.airt.atlas import atlas_attack",
             "from dreadnode.airt.assessment import Assessment",
             "from dreadnode.airt.analytics import analyze",

--- a/capabilities/ai-red-teaming/tests/test_attack_runner.py
+++ b/capabilities/ai-red-teaming/tests/test_attack_runner.py
@@ -1006,6 +1006,14 @@ class TestAtlasGeneration:
         assert "await atlas_attack(" in script
         assert 'SCENARIO_NAME = "finops"' in script
         assert "TOTAL_BUDGET = 8" in script
+        # Regression: the proxy-routing block calls get_generator(...), so the
+        # generated script MUST import it (compile() only checks syntax, not
+        # name resolution, so a missing import is a runtime NameError).
+        assert "get_generator(" in script
+        assert (
+            "from dreadnode.generators.generator import get_generator, GenerateParams"
+            in script
+        )
         # Default objective catalog is embedded with category coverage.
         assert "OBJECTIVES = " in script
         for cat in ("TW", "EA", "CB", "DE", "GH", "MP", "TB", "RP"):


### PR DESCRIPTION
## Summary
Generated ATLAS campaign scripts crashed at runtime with `NameError: get_generator`. The dedicated `_build_atlas_imports()` omitted the `from dreadnode.generators.generator import get_generator, GenerateParams` import that the shared `_build_proxy_routing()` block calls (`TARGET_GENERATOR = get_generator(...)`, and `_resolve_dn_model` for `dn/*` models). `compile()` only validates syntax, so the existing test didn't catch it.

## Root cause
`_generate_atlas_single` assembles imports via `_build_atlas_imports()` (not the general `_build_imports()`, which already includes the import). The atlas variant was missing that one line.

## Fix
- Add the `get_generator, GenerateParams` import to `_build_atlas_imports()`.
- Add a static regression assertion in `TestAtlasGeneration` (import + usage must both be present).

## Validation
- `pytest tests/test_attack_runner.py -k Atlas` → 10 passed.
- Regenerated the ATLAS script and ran it end-to-end against a deployed AWS App Runner mesh env → SDK ATLAS campaign registered + completed an assessment on dev (no NameError); previously crashed before any attack.