### PR TITLE
fix(ai-red-teaming): import get_generator in generated agentic script

### DIFF
--- a/capabilities/ai-red-teaming/scripts/attack_runner.py
+++ b/capabilities/ai-red-teaming/scripts/attack_runner.py
@@ -4324,6 +4324,8 @@ def _build_agentic_imports(attacks: list[dict], transforms: list[dict], has_scor
         "",
         "import dreadnode as dn",
         "from dreadnode import task",
+        # Required by the proxy-routing block (get_generator/GenerateParams).
+        "from dreadnode.generators.generator import get_generator, GenerateParams",
     ]
 
     attack_funcs = set()

--- a/capabilities/ai-red-teaming/tests/test_attack_runner.py
+++ b/capabilities/ai-red-teaming/tests/test_attack_runner.py
@@ -1039,6 +1039,33 @@ class TestAtlasGeneration:
         assert "Authorization" in script
 
 
+_AGENTIC_BASE = {
+    "attack_type": "goat",
+    "goal": "get the agent to misuse a privileged tool",
+    "agent_url": "http://localhost:8000/attack",
+    "agent_preset": "custom",
+    "attacker_model": "groq scout",
+    "n_iterations": 4,
+    "generate_only": True,
+}
+
+
+class TestAgenticGeneration:
+    def test_generated_script_compiles_and_imports_get_generator(self):
+        result = _generate_method("generate_agentic_attack", _AGENTIC_BASE)
+        assert "error" not in result, result.get("error")
+        script = Path(result["filepath"]).read_text()
+        compile(script, result["filepath"], "exec")
+        # Regression: the proxy-routing block calls get_generator(...), so the
+        # generated script MUST import it (compile() only checks syntax, so a
+        # missing import is a runtime NameError).
+        assert "get_generator(" in script
+        assert (
+            "from dreadnode.generators.generator import get_generator, GenerateParams"
+            in script
+        )
+
+
 class TestAtlasValidation:
     def test_missing_agent_url_errors(self):
         params = {k: v for k, v in _ATLAS_BASE.items() if k != "agent_url"}


### PR DESCRIPTION
## Summary
Same class of bug as #100, in a different code path. Generated **agentic** attack scripts (`generate_agentic_attack`) call `get_generator(...)` in the proxy-routing block but `_build_agentic_imports` never imported it, so every generated agentic script raised `NameError: get_generator` at runtime. This path was previously untested, so it went unnoticed.

## Fix
- Add `from dreadnode.generators.generator import get_generator, GenerateParams` to `_build_agentic_imports`.
- Add `TestAgenticGeneration` with a static regression assertion (import + usage present) — `compile()` only checks syntax, not name resolution.

## Scope
Audited all six imports builders. `_build_imports`, `_build_atlas_imports` (fixed in #100) and `_build_multimodal_imports` already import it. `_build_image_imports` / `_build_tabular_imports` omit it too, but their generators do NOT include the proxy-routing block (no `get_generator` usage), so no runtime error — left unchanged to avoid an unused import.

## Validation
- `pytest -k "Agentic or Atlas"` → 11 passed.
- Regenerated + ran an agentic campaign against a deployed AWS mesh env → assessment registered + "Attack completed successfully" on dev (previously crashed before any attack).