### PR TITLE
fix(ai-red-teaming): scope get_session_context to AIRT + make it pull-only (CAP-1169)

### DIFF
--- a/capabilities/ai-red-teaming/agents/ai-red-teaming-agent.md
+++ b/capabilities/ai-red-teaming/agents/ai-red-teaming-agent.md
@@ -176,7 +176,7 @@ The AI Red Teaming capability provides these tools:
 **Session Context (Iterative Refinement):**
 
 - **save_session_context** — Save current attack context (target, goal, results) for follow-up attacks
-- **get_session_context** — Retrieve previous attack context to auto-fill parameters
+- **get_session_context** — Pull-only, red-teaming resume aid: call ONLY when continuing a prior attack (e.g. "try another attack", "add transforms") to auto-fill target/goal/models. Do NOT call it to start a task or for non-red-teaming work.
 - **clear_session_context** — Clear session to start fresh
 
 **Results & Analytics:**

--- a/capabilities/ai-red-teaming/capability.yaml
+++ b/capabilities/ai-red-teaming/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: ai-red-teaming
-version: "1.10.0"
+version: "1.10.1"
 description: >
   Probe the security and safety of AI applications, agents, and foundation models.
   Orchestrates adversarial attack workflows to discover vulnerabilities in LLMs,

--- a/capabilities/ai-red-teaming/tools/session.py
+++ b/capabilities/ai-red-teaming/tools/session.py
@@ -102,16 +102,17 @@ def save_session_context(
 
 @safe_tool
 def get_session_context() -> str:
-    """Retrieve the current session context for iterative refinement.
+    """Retrieve saved AI red-teaming session context when *resuming* a prior attack.
 
-    Returns the last target, goal, models, transforms, and results
-    so you can build on previous attacks without the user re-specifying
-    everything. Use this at the start of follow-up commands like
-    "try another attack" or "add transforms".
+    AI-red-teaming only. Use ONLY to continue a previous red-teaming assessment —
+    e.g. follow-ups like "try another attack", "add transforms", or "re-run against
+    the same target" — so you don't have to re-specify the target/goal/models. It is
+    pull-only: you do NOT need to call this to begin a task, and it is not relevant to
+    non-red-teaming work. Returns an empty result if no prior red-teaming session exists.
     """
     session = _load()
     if not session or "current" not in session:
-        return "No session context found. Run an attack first to establish context."
+        return "No prior red-teaming session. Nothing to resume — proceed with the task directly."
 
     current = session["current"]
     lines = [


### PR DESCRIPTION
Closes CAP-1169.

## Problem
`get_session_context`'s docstring said *"use this at the start of follow-up commands… so you can build on previous attacks"* — a **push** instruction that primed agents to open with it. When the AIRT capability is co-attached with another (e.g. web-security), the agent reaches for this AIRT tool first even on non-red-teaming primitives → occasional spins + odd demos. The goal is to stop that **without temporarily disabling AIRT**.

## Change (priming fix — pull-only + AIRT-scoped by description)
- Reword the `get_session_context` docstring: **pull-only, red-teaming-only, resume aid** — call ONLY to continue a prior attack (try another attack / add transforms); **do NOT call to start** a task; **not relevant to non-red-teaming work**.
- Soften the empty return: `"No prior red-teaming session. Nothing to resume — proceed with the task directly."` (was *"Run an attack first…"*, which invited a spin).
- Scope the agent-prompt tool description to match.
- Patch bump 1.10.0 → 1.10.1.

No behavior change when genuinely resuming an AIRT attack.

## Scope note (soft vs hard)
This is a **description/priming** fix — the tool is still present in the toolset, but its wording steers the agent away from it for non-AIRT tasks. If we want it **hard-hidden** when a non-AIRT capability is selected, that's a follow-up at the capability-loader level (conditional tool exposure by active capability), not something a docstring controls.