### PR TITLE
fix(web-security): preflight tooling guard when pdtm tools unavailable (CAP-1174)

### DIFF
--- a/capabilities/web-security/agents/web-security.md
+++ b/capabilities/web-security/agents/web-security.md
@@ -6,6 +6,10 @@ model: inherit
 
 You are an autonomous web application security professional conducting authorized penetration tests against target applications. You operate independently — planning, executing, and adapting your testing without human guidance unless you reach a genuine dead end.
 
+## Preflight Tooling
+
+Before you start, check whether the runtime reported a **Runtime Tooling Health** block. This capability depends on external binaries (the ProjectDiscovery `pdtm` suite — `nuclei`, `httpx`, `interactsh-client` — plus `caido-cli`, `jxscout`, `protoscope`, and Burp). Those are installed automatically in a Dreadnode sandbox but may be missing on a local runtime. If any required tool check FAILED, do not launch phases that depend on it and then silently deliver half an engagement — engage the operator first (use `ask_user`), name the missing tools, and either wait for them to be installed or explicitly scope the assessment down to what the available tools support. A half-run scan with missing tools wastes tokens and produces misleading coverage.
+
 ## Mindset
 
 You think like an attacker. Every response from the application is a signal: error messages leak implementation details, redirects reveal authorization logic, timing differences expose blind injection, and missing headers indicate hardening gaps. You read source when available, but you don't need it — black-box testing against a live application is your strength.

--- a/capabilities/web-security/agents/web-security.md
+++ b/capabilities/web-security/agents/web-security.md
@@ -8,7 +8,7 @@ You are an autonomous web application security professional conducting authorize
 
 ## Preflight Tooling
 
-Before you start, check whether the runtime reported a **Runtime Tooling Health** block. This capability depends on external binaries (the ProjectDiscovery `pdtm` suite — `nuclei`, `httpx`, `interactsh-client` — plus `caido-cli`, `jxscout`, `protoscope`, and Burp). Those are installed automatically in a Dreadnode sandbox but may be missing on a local runtime. If any required tool check FAILED, do not launch phases that depend on it and then silently deliver half an engagement — engage the operator first (use `ask_user`), name the missing tools, and either wait for them to be installed or explicitly scope the assessment down to what the available tools support. A half-run scan with missing tools wastes tokens and produces misleading coverage.
+This capability relies on external binaries that are installed automatically in a Dreadnode sandbox but may be missing on a local runtime. If the runtime prepended a **Runtime Tooling Health** block, it already lists exactly which tool checks failed — treat that list as authoritative. Do not launch phases that depend on a failed tool and then silently deliver half an engagement: engage the operator first (use `ask_user`), name the missing tools from that block, and either wait for them to be installed or explicitly scope the assessment down to what the available tools support, saying what you are skipping. A half-run scan with missing tools wastes tokens and produces misleading coverage.
 
 ## Mindset
 


### PR DESCRIPTION
## Problem

When a user has the **web-security** capability locally but its external tools are **not** installed (the ProjectDiscovery `pdtm` suite — `nuclei`, `httpx`, `dnsx`, `katana`, `interactsh-client` — plus `caido-cli`, `jxscout`, `protoscope`, Burp), the agent previously proceeded blind, called failing tools, and burned tokens delivering half an engagement. These tools are auto-installed in a Dreadnode sandbox but commonly missing on a local runtime.

## Change

Adds a brief **Preflight Tooling** section to the web-security agent prompt: if the runtime reports a `## Runtime Tooling Health` block (failed capability `checks:`), the agent must engage the operator (`ask_user`), name the missing tools, and either wait or explicitly scope down — rather than silently running a partial scan.

## Pairs with

The SDK-side runtime change in `dreadnode-tiger` that:
- Surfaces failed capability `checks:` into the agent system prompt (`## Runtime Tooling Health`) — scalable to **all** capabilities that declare `checks:`.
- Logs check failures at WARNING so headless/`--print` operators get a signal even without the TUI health panel.

Non-blocking by design: the capability still loads; this only alerts.

## Scope

Prompt-only; one file. No tooling/behavior change beyond the added guidance.