### PR TITLE
docs(ai-red-teaming): unify capability counts (590+ transforms, 70+ attacks, 140+ scorers)

### DIFF
--- a/capabilities/ai-red-teaming/agents/ai-red-teaming-agent.md
+++ b/capabilities/ai-red-teaming/agents/ai-red-teaming-agent.md
@@ -4,8 +4,8 @@ model: anthropic/claude-opus-4-20250514
 description: >
   Unified AI Red Teaming agent for probing security and safety vulnerabilities in LLMs,
   agentic systems, MCP servers, multi-agent architectures, ML classifiers, and custom AI endpoints.
-  Orchestrates 45 attack algorithms (41 LLM + 4 adversarial ML samplers), 500+ transforms,
-  an extensive scorer catalog, and 260 bundled harm goals across OWASP LLM Top 10,
+  Orchestrates 70+ attack strategies covering traditional ML and generative AI, 590+ transforms,
+  140+ scorers, and 260 bundled harm goals across OWASP LLM Top 10,
   OWASP ASI01-ASI10, and MITRE ATLAS frameworks.
 ---
 
@@ -205,7 +205,7 @@ When you call `generate_attack`, it:
 
 ## Attack Types (common subset)
 
-The capability ships 41 LLM attack algorithms plus 4 adversarial ML samplers; the table below covers the most common picks. Use `"Show me all available attacks"` to enumerate the full set.
+The capability ships 70+ attack strategies covering traditional ML and generative AI (generative jailbreaks plus adversarial-ML evasion, extraction, membership inference, and inversion); the table below covers the most common picks. Use `"Show me all available attacks"` to enumerate the full set.
 
 | Attack | Best For | Query Budget |
 |--------|----------|-------------|
@@ -241,7 +241,7 @@ The capability ships 41 LLM attack algorithms plus 4 adversarial ML samplers; th
 
 ## Transform Catalog
 
-📖 **Complete catalog**: See [transform-catalog.md](./transform-catalog.md) for full reference (500+ transforms across encoding, cipher, persuasion, language, MCP, multi-agent, exfiltration, and more)
+📖 **Complete catalog**: See [transform-catalog.md](./transform-catalog.md) for full reference (590+ transforms across encoding, cipher, persuasion, language, MCP, multi-agent, exfiltration, and more)
 
 **Common transforms include**:
 - **Encoding**: `base64`, `hex`, `leetspeak`, `morse`, `unicode_escape`

--- a/capabilities/ai-red-teaming/capability.yaml
+++ b/capabilities/ai-red-teaming/capability.yaml
@@ -11,7 +11,7 @@ description: >
   and NIST AI RMF compliance frameworks. Also probes traditional black-box ML
   classifiers: model extraction (model stealing), membership inference (training-data
   leakage), and model evasion (adversarial examples) across tabular, image, and text.
-  500+ transforms, an extensive scorer catalog, and 260 bundled harm goals across 25
+  590+ transforms, 140+ scorers, and 260 bundled harm goals across 25
   sub-categories in safety, security, and agentic tiers.
 
 agents:


### PR DESCRIPTION
## Summary

The `ai-red-teaming` capability advertised stale, self-inconsistent counts (agent.md: "45 attack algorithms (41 LLM + 4 adversarial ML samplers), 500+ transforms, an extensive scorer catalog"; capability.yaml: "500+ transforms"). This aligns them with the verified `origin/main` SDK registries and the matching dreadnode-tiger docs PR.

## Verified figures (SDK origin/main)

- **70+ attack strategies** covering traditional ML and generative AI — 72 total (47 generative jailbreaks + 25 adversarial-ML: evasion, extraction, membership inference, inversion). The old "4 adversarial ML samplers" was off by ~21.
- **590+ transforms** — 599 genuine transform factories.
- **140+ scorers** — 142 in `dreadnode.scorers.__all__`.
- **260 bundled harm goals** — unchanged.

## Changes

- `agents/ai-red-teaming-agent.md` — description block, Attack Types intro (line 208), Transform Catalog note (line 244)
- `capability.yaml` — capability description

## Not in this PR (flagged)

- `skills/transform-reference` ("all 183 transforms") and `skills/scorer-reference` ("all 84 scorers") are literal enumerated catalogs — they need regeneration against the current SDK, handled separately so headline and list stay consistent.
- `skills/compliance-mapping` has granular per-category counts ("12 attack algorithms", "200+ transforms") that also need a pass.

## Test plan

- [ ] Capability loads / validates
- [ ] Numbers match the dreadnode-tiger AIRT docs PR