### PR TITLE
fix(web-security): bump to 1.6.0 to unblock dev capability sync

### DIFF
--- a/capabilities/web-security/capability.yaml
+++ b/capabilities/web-security/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: web-security
-version: "1.5.0"
+version: "1.6.0"
 description: >
   Web application penetration testing with 70+ attack technique playbooks
   covering request smuggling, cache poisoning, SSRF, SSTI, DOM


### PR DESCRIPTION
## What

Bump `web-security` capability version `1.5.0` -> `1.6.0`.

## Why

The **Sync Capabilities** workflow ([run 31614567028](https://github.com/dreadnode/capabilities/actions/runs/31614567028)) failed on the **Sync to dev** job:

```
✗ web-security: Client error '400 Bad Request' for url
  'https://dev.app.dreadnode.io/api/v1/dreadnode/web-security/manifests/1.5.0'
Synced 26: 1 uploaded, 24 skipped, 1 failed
```

Root cause: three content changes landed on web-security **after** the last version bump (`d6919a6`, which set 1.5.0) without bumping the version:

- `6f80ddf` add response-queue-poisoning skill (#116)
- `53bec99` tool-agnostic preflight guidance
- `2cb04ae` pdtm preflight guard (CAP-1174)

Dev already has an immutable `1.5.0` stored, so re-publishing `1.5.0` with different content is rejected (400). Staging/prod succeeded only because they hadn't stored `1.5.0` yet — leaving envs inconsistent.

Bumping to `1.6.0` publishes a fresh immutable version cleanly across dev/staging/prod. Minor bump because a new skill (feature) was added.

## Test plan

- [ ] Re-run Sync Capabilities on merge; `web-security` uploads to dev/staging/prod without 400
- [ ] `Create capability releases` tags `capability/web-security/v1.6.0`