### PR TITLE
chore(web-security): bump version to 1.6.0

### DIFF
--- a/capabilities/web-security/capability.yaml
+++ b/capabilities/web-security/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: web-security
-version: "1.5.0"
+version: "1.6.0"
 description: >
   Web application penetration testing with 70+ attack technique playbooks
   covering request smuggling, cache poisoning, SSRF, SSTI, DOM


### PR DESCRIPTION
## Summary

Bumps the web-security capability version `1.5.0 → 1.6.0` to fix the failed manifest sync after PR #116.

## Why
PR #116 added the `response-queue-poisoning` skill but did not bump the version. The capability-sync CI job then tried to upload manifest `web-security/manifests/1.5.0`, which was already published (by the earlier Caido Go MCP merge). The platform rejects re-publishing an existing immutable version, returning `400 Bad Request`.

Bumping to `1.6.0` (minor bump for the additive skill) lets the sync publish a fresh manifest. This matches the repo convention where each functional web-security change bumps the version.

Failed run: https://github.com/dreadnode/capabilities/actions/runs/31614567028/job/94177341121