### PR TITLE
fix(attack-surface-management): provision runtime dependencies

### DIFF
--- a/capabilities/attack-surface-management/capability.yaml
+++ b/capabilities/attack-surface-management/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: attack-surface-management
-version: "2.0.0"
+version: "2.0.1"
 description: >
   External attack surface management with BBOT reconnaissance scanning,
   Neo4j graph database analysis, Shodan internet intelligence, and
@@ -47,6 +47,8 @@ mcp:
       init_timeout: 30
 
 dependencies:
+  packages:
+    - nmap
   python:
     - "badsecrets~=0.13.47"
     - "baddns~=1.12.294"
@@ -55,12 +57,24 @@ dependencies:
     - "extractous~=0.3.0"
     - "asyncpg>=0.31.0"
     - "dnspython>=2.7.0,<2.8.0"
+    - "fastmcp>=2.0"
     - "neo4j>=5.28.1"
     - "shodan>=1.31.0"
+    - "aiodocker>=0.24.0"
     - "tldextract>=5.3.1,<6.0.0"
     - "pillow>=11.3.0"
     - "pyOpenSSL~=25.3.0"
     - "loguru>=0.7.0"
+
+checks:
+  - name: bbot
+    command: "command -v bbot >/dev/null 2>&1"
+  - name: nmap
+    command: "command -v nmap >/dev/null 2>&1"
+  - name: neo4j-python
+    command: "python3 -c 'import neo4j'"
+  - name: fastmcp-python
+    command: "python3 -c 'import fastmcp'"
 
 author:
   name: Dreadnode

--- a/capabilities/attack-surface-management/pyproject.toml
+++ b/capabilities/attack-surface-management/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "attack-surface-management"
-version = "1.1.27"
+version = "2.0.1"
 requires-python = ">=3.10"
 dependencies = [
     "badsecrets~=0.13.47",

--- a/capabilities/attack-surface-management/tests/test_bbot_mcp.py
+++ b/capabilities/attack-surface-management/tests/test_bbot_mcp.py
@@ -6,6 +6,25 @@ import json
 from pathlib import Path
 
 import pytest
+import yaml
+
+
+CAPABILITY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_manifest_declares_runtime_dependencies_and_checks():
+    manifest = yaml.safe_load((CAPABILITY_ROOT / "capability.yaml").read_text())
+
+    assert "nmap" in manifest["dependencies"]["packages"]
+    assert "bbot" in manifest["dependencies"]["python"]
+    assert "neo4j>=5.28.1" in manifest["dependencies"]["python"]
+    assert "fastmcp>=2.0" in manifest["dependencies"]["python"]
+
+    checks = {check["name"]: check["command"] for check in manifest["checks"]}
+    assert "bbot" in checks
+    assert "nmap" in checks
+    assert "neo4j-python" in checks
+    assert "fastmcp-python" in checks
 
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "mcp" / "bbot.py"


### PR DESCRIPTION
## Summary
- declare the native `nmap` package for managed sandbox provisioning
- align manifest Python dependencies with the capability package (`fastmcp`, `aiodocker`)
- add readiness checks for `bbot`, `nmap`, `neo4j`, and `fastmcp`
- bump the capability/package version to `2.0.1`

## Validation
- `pre-commit run --files capabilities/attack-surface-management/capability.yaml capabilities/attack-surface-management/pyproject.toml capabilities/attack-surface-management/tests/test_bbot_mcp.py`
- `pytest -q tests/test_worker_coordinator.py`
- `pytest -q tests/test_bbot_mcp.py -k manifest`
- `just validate` (timed out after 120s; targeted checks passed)

## Scope
This is intentionally a KISS packaging fix. It provisions declared runtime dependencies and surfaces missing prerequisites early. It does not provision a Neo4j server; managed deployments must still provide Neo4j or use the documented `graph_api_url` mode.
