### PR TITLE
fix(airt): bump capability version to 1.11.0 (unblock dev sync)

### DIFF
--- a/capabilities/ai-red-teaming/capability.yaml
+++ b/capabilities/ai-red-teaming/capability.yaml
@@ -1,6 +1,6 @@
 schema: 1
 name: ai-red-teaming
-version: "1.10.1"
+version: "1.11.0"
 description: >
   Probe the security and safety of AI applications, agents, and foundation models.
   Orchestrates adversarial attack workflows to discover vulnerabilities in LLMs,


### PR DESCRIPTION
The multistep tool-attack tool (#134) changed capability content without bumping the version, so **Sync Capabilities** failed on dev with `409 Conflict: Capability version is immutable: dreadnode/ai-red-teaming@1.10.1`. Bumps the version to 1.11.0 so the sync uploads the new content. No functional change.