### PR TITLE
fix(dotnet-reversing): install deps under home now the workspace mount is gone

### DIFF
--- a/capabilities/dotnet-reversing/dotnet_agent/bootstrap.py
+++ b/capabilities/dotnet-reversing/dotnet_agent/bootstrap.py
@@ -2,8 +2,8 @@
 Bootstrap script to install .NET and ILSpy dependencies.
 
 This module handles first-time setup of .NET runtime and ILSpy libraries
-in the Dreadnode sandbox environment. Dependencies are installed to the
-workspace directory so they persist across sandbox restarts.
+in the Dreadnode sandbox environment. Dependencies are installed under the
+home directory and last for the life of the sandbox.
 
 Usage:
     from dotnet_agent.bootstrap import ensure_dependencies
@@ -20,31 +20,9 @@ from pathlib import Path
 # Configuration
 # =============================================================================
 
-# Install to workspace so it persists across sandbox restarts.
-# /home/user/workspace is S3-mounted and survives sandbox recreation.
-# For local runtime, falls back to ~/.dreadnode/deps
-SANDBOX_WORKSPACE = Path("/home/user/workspace")
-LOCAL_FALLBACK = Path.home() / ".dreadnode" / "deps"
-
-
-def _get_deps_dir() -> Path:
-    """Get the appropriate deps directory based on environment."""
-    if SANDBOX_WORKSPACE.exists() and SANDBOX_WORKSPACE.is_dir():
-        # Check if it's a mount point (sandbox) or just exists (local dev)
-        try:
-            if SANDBOX_WORKSPACE.is_mount():
-                return SANDBOX_WORKSPACE / ".dreadnode" / "deps"
-        except OSError:
-            pass
-        # If workspace exists but isn't a mount, still use it in sandbox-like envs
-        if (SANDBOX_WORKSPACE / ".dreadnode").exists() or os.environ.get(
-            "DREADNODE_SANDBOX"
-        ):
-            return SANDBOX_WORKSPACE / ".dreadnode" / "deps"
-    return LOCAL_FALLBACK
-
-
-DEPS_DIR = _get_deps_dir()
+# The sandbox workspace is an ordinary local directory with no lifetime beyond
+# the sandbox itself, so deps go under the home directory in every environment.
+DEPS_DIR = Path.home() / ".dreadnode" / "deps"
 DOTNET_ROOT = DEPS_DIR / "dotnet"
 ILSPY_LIB_DIR = DEPS_DIR / "ilspy"
 
@@ -65,9 +43,8 @@ def ensure_dependencies(verbose: bool = True) -> bool:
     """
     Install .NET and ILSpy if not present. Returns True if ready.
 
-    This function is idempotent - safe to call multiple times.
-    Dependencies are installed to a persistent directory so subsequent
-    sandbox starts skip the download.
+    This function is idempotent - safe to call multiple times. The download
+    is skipped once the dependencies are present in this sandbox.
 
     Args:
         verbose: Print progress messages (default True)


### PR DESCRIPTION
Found while reviewing dreadnode-tiger#2400 (ENG-8273, remove E2B workspace mount).

## What was wrong

`dotnet_agent/bootstrap.py` picked its dependency directory by probing `/home/user/workspace`:

```python
if SANDBOX_WORKSPACE.is_mount():
    return SANDBOX_WORKSPACE / ".dreadnode" / "deps"
if (SANDBOX_WORKSPACE / ".dreadnode").exists() or os.environ.get("DREADNODE_SANDBOX"):
    return SANDBOX_WORKSPACE / ".dreadnode" / "deps"
return LOCAL_FALLBACK
```

With the platform's object-storage FUSE mount removed, every one of those branches is dead:

- `is_mount()` is now always false — the workspace is an ordinary local directory.
- `DREADNODE_SANDBOX` is set nowhere in the platform (no hits across the API, the SDK, or the deployment config).
- A fresh sandbox has no `/home/user/workspace/.dreadnode`, and nothing creates one now that deps resolve to the fallback.

So the probe already resolved to `~/.dreadnode/deps` in every environment. This installs there directly and deletes the dead branch.

## The false claims

Two comments told the agent something that is no longer true, in a file the agent reads:

- `"Dependencies are installed to the workspace directory so they persist across sandbox restarts."`
- `"/home/user/workspace is S3-mounted and survives sandbox recreation."`

Both are corrected. The behavioural consequence — .NET and ILSpy are re-downloaded on a new sandbox rather than reused from object storage — is inherent to the mount removal, not to this change; this only stops the code and its documentation from claiming otherwise.

## Verification

No behaviour change in any reachable environment: the fallback branch is what already ran. `ruff check --select F401,F821` clean (`os` is still used for the `DOTNET_ROOT`/`PATH` exports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDDm7JrA7K5N1CLeWnFdyr